### PR TITLE
Breaking: In error message, do not prefix the field name.

### DIFF
--- a/proca/lib/proca_web/helper.ex
+++ b/proca/lib/proca_web/helper.ex
@@ -46,10 +46,10 @@ defmodule ProcaWeb.Helper do
   # handle messages list (it's a list of %{message: "123"})
   def flatten_errors([], _), do: []
 
-  def flatten_errors([%{message: msg} = m | other_msg], path = [lastkey | _])
+  def flatten_errors([%{message: msg} = m | other_msg], path)
        when map_size(m) == 1 do
     [%{
-        message: "#{lastkey}: #{msg}",
+        message: msg,
         path: Enum.reverse(path)
      } | flatten_errors(other_msg, path)]
   end

--- a/proca/test/contact/eci_data_test.exs
+++ b/proca/test/contact/eci_data_test.exs
@@ -101,7 +101,7 @@ defmodule EciDataTest do
 
     assert [
              %{
-               message: "documentNumber: has invalid format",
+               message: "has invalid format",
                path: ["nationality", "documentNumber"]
              }
            ] = format_errors(c)
@@ -114,14 +114,14 @@ defmodule EciDataTest do
     c = EciData.from_input(no_dn)
 
     assert not c.valid?
-    assert [%{message: "documentNumber: can't be blank", path: ["nationality", "documentNumber"]}] =
+    assert [%{message: "can't be blank", path: ["nationality", "documentNumber"]}] =
              format_errors(c)
 
     no_dt = %{d | nationality: %{n | document_type: nil}}
     c = EciData.from_input(no_dt)
     assert not c.valid?
 
-    assert [%{message: "documentType: can't be blank", path: ["nationality", "documentType"]}] =
+    assert [%{message: "can't be blank", path: ["nationality", "documentType"]}] =
              format_errors(c)
 
     no_docs = %{d | nationality: %{country: n.country}}
@@ -130,10 +130,10 @@ defmodule EciDataTest do
 
     assert [
              %{
-               message: "documentNumber: can't be blank",
+               message: "can't be blank",
                path: ["nationality", "documentNumber"]
              },
-             %{message: "documentType: can't be blank", path: ["nationality", "documentType"]}
+             %{message: "can't be blank", path: ["nationality", "documentType"]}
            ] = format_errors(c)
 
     wrong_type = %{d | nationality: %{n | document_type: "id.card"}}
@@ -142,7 +142,7 @@ defmodule EciDataTest do
 
     assert [
              %{
-               message: "documentNumber: has invalid format",
+               message: "has invalid format",
                path: ["nationality", "documentNumber"]
              }
            ] = format_errors(c)
@@ -151,7 +151,7 @@ defmodule EciDataTest do
     c = EciData.from_input(unsupported_type)
     assert not c.valid?
 
-    assert [%{message: "documentType: is invalid", path: ["nationality", "documentType"]}] =
+    assert [%{message: "is invalid", path: ["nationality", "documentType"]}] =
              format_errors(c)
 
     dn_spaces = %{d | nationality: %{n | document_number: "R 1234567" } }
@@ -173,7 +173,7 @@ defmodule EciDataTest do
     d = %{gr | address: %{gr.address | country: nil}}
     c = EciData.from_input(d)
     assert not c.valid?
-    assert [%{message: "country: can't be blank", path: ["address", "country"]}] = format_errors(c)
+    assert [%{message: "can't be blank", path: ["address", "country"]}] = format_errors(c)
   end
 
   test "Greek with missing locality", %{gr: gr} do
@@ -181,7 +181,7 @@ defmodule EciDataTest do
     c = EciData.from_input(d)
     assert not c.valid?
 
-    assert [%{message: "locality: can't be blank", path: ["address", "locality"]}] =
+    assert [%{message: "can't be blank", path: ["address", "locality"]}] =
              format_errors(c)
   end
 
@@ -190,7 +190,7 @@ defmodule EciDataTest do
     c = EciData.from_input(d)
     assert not c.valid?
 
-    assert [%{message: "postcode: has invalid format", path: ["address", "postcode"]}] =
+    assert [%{message: "has invalid format", path: ["address", "postcode"]}] =
              format_errors(c)
   end
 

--- a/proca/test/proca_web/api/eci_security_test.exs
+++ b/proca/test/proca_web/api/eci_security_test.exs
@@ -39,16 +39,16 @@ defmodule ProcaWeb.Api.EciSecurityTest do
 
   test "Sending HTML tags in fields fails", %{conn: conn, pages: [ap]} do
     bad_input = [
-      {%{first_name: "<SCRIPT>alert()"}, "firstName: has invalid format"},
-      {%{first_name: "'-alert(1)-'"}, "firstName: has invalid format"},
-      {%{first_name: "http://217.69.168.225"}, "firstName: has invalid format"},
-      {%{first_name: "%77%77%77%2E%6B%6F%6D%70%75%72%69%74%79%2E%64%65"}, "firstName: has invalid format"},
-      {%{first_name: "http://0000331.0x0000045.168.0xE1"}, "firstName: has invalid format"},
-      {%{last_name: "<SCRIPT>alert()"}, "lastName: has invalid format"},
+      {%{first_name: "<SCRIPT>alert()"}, "has invalid format"},
+      {%{first_name: "'-alert(1)-'"}, "has invalid format"},
+      {%{first_name: "http://217.69.168.225"}, "has invalid format"},
+      {%{first_name: "%77%77%77%2E%6B%6F%6D%70%75%72%69%74%79%2E%64%65"}, "has invalid format"},
+      {%{first_name: "http://0000331.0x0000045.168.0xE1"}, "has invalid format"},
+      {%{last_name: "<SCRIPT>alert()"}, "has invalid format"},
       {%{birth_date: ""},
        "Argument \"contact\" has invalid value {nationality: {country: \"at\", documentType: \"passport\", documentNumber: \"R1234567\"}, firstName: \"Olaf\", lastName: \"Foobar\", birthDate: \"\", address: {country: \"\", postcode: \"\", locality: \"\", street: \"\"}}.\nIn field \"birthDate\": Expected type \"Date\", found \"\"."
        },
-      {%{nat_country: "fr", add_postcode: "0000-000000000000000-0000"}, "postcode: has invalid format"}
+      {%{nat_country: "fr", add_postcode: "0000-000000000000000-0000"}, "has invalid format"}
       
     ]
 
@@ -65,7 +65,7 @@ defmodule ProcaWeb.Api.EciSecurityTest do
 
   test "Send a very long field", %{conn: conn, pages: [ap]} do
     bad_input = [
-      {%{first_name: String.duplicate("Foo", 2000)}, "firstName: should be at most 64 character(s)"}
+      {%{first_name: String.duplicate("Foo", 2000)}, "should be at most 64 character(s)"}
     ]
  
     bad_input

--- a/proca/test/proca_web/helper_test.exs
+++ b/proca/test/proca_web/helper_test.exs
@@ -8,6 +8,6 @@ defmodule ProcaWeb.HelperTest do
     errors = [value: {"can't be blank", [validation: :required]}]
     ch = change(%Action{})
     ch = %{ch | valid?: false, errors: errors}
-    assert Helper.format_errors(ch) == [%{message: "value: can't be blank", path: ["value"]}]
+    assert Helper.format_errors(ch) == [%{message: "can't be blank", path: ["value"]}]
   end
 end


### PR DESCRIPTION
This information is already in path list