### PR TITLE
Double opt in and other events

### DIFF
--- a/proca/lib/proca/action.ex
+++ b/proca/lib/proca/action.ex
@@ -110,6 +110,7 @@ defmodule Proca.Action do
   def all(q, [{:processing_status, status} | kw]) when is_list(status) do
     q
     |> where([a], a.processing_status in ^status)
+    |> all(kw)
   end
 
   def clear_transient_fields_query(action = %Action{id: id, fields: fields, action_page: page}) do

--- a/proca/lib/proca/action_page.ex
+++ b/proca/lib/proca/action_page.ex
@@ -66,6 +66,7 @@ defmodule Proca.ActionPage do
       :locale,
       ~r/^[a-z]{2}(_[A-Z]{2})?$/
     )
+    |> Proca.Service.EmailTemplate.validate_exists(:thank_you_template)
     |> change(assocs)
   end
 
@@ -189,11 +190,14 @@ defmodule Proca.ActionPage do
   def all(q, [{:name, name} | kw]), do: where(q, [a], a.name == ^name) |> all(kw)
   def all(q, [{:url, name} | kw]), do: all(q, [{:name, name} | kw])
 
-  def all(q, [{:trash, trash} | kw]) do
-    q
-    |> where([ap], is_nil(ap.campaign_id) == ^trash)
-    |> all(kw)
-  end
+  def all(q, [{:org, %Proca.Org{id: org_id}} | kw]),
+    do: where(q, [a], a.org_id == ^org_id) |> all(kw)
+
+  # def all(q, [{:trash, trash} | kw]) do
+  #   q
+  #   |> where([ap], is_nil(ap.campaign_id) == ^trash)
+  #   |> all(kw)
+  # end
 
   def contact_schema(%ActionPage{campaign: %Campaign{contact_schema: cs}}) do
     case cs do

--- a/proca/lib/proca/org.ex
+++ b/proca/lib/proca/org.ex
@@ -36,10 +36,9 @@ defmodule Proca.Org do
     field :email_from, :string
     belongs_to :template_backend, Proca.Service
 
-    # double opt in configuration
-    # XXX maybe move these two into config
-    field :email_opt_in, :boolean, default: false
-    field :email_opt_in_template, :string
+    # supporter confirm in configuration
+    field :supporter_confirm, :boolean, default: false
+    field :supporter_confirm_template, :string
 
     # confirming and delivery configuration
     field :custom_supporter_confirm, :boolean, default: false
@@ -66,8 +65,8 @@ defmodule Proca.Org do
       :title,
       :contact_schema,
       :email_from,
-      :email_opt_in,
-      :email_opt_in_template,
+      :supporter_confirm,
+      :supporter_confirm_template,
       :config,
       :high_security,
       :custom_supporter_confirm,
@@ -81,7 +80,7 @@ defmodule Proca.Org do
     |> validate_format(:name, ~r/^[[:alnum:]_-]+$/)
     |> unique_constraint(:name)
     |> Proca.Contact.Input.validate_email(:email_from)
-    |> validate_change(:email_opt_in_template, fn f, tmpl_name ->
+    |> validate_change(:supporter_confirm_template, fn f, tmpl_name ->
       case EmailTemplateDirectory.ref_by_name_reload(org, tmpl_name) do
         {:ok, _ref} -> []
         :not_found -> [{f, "template not found"}]

--- a/proca/lib/proca/org.ex
+++ b/proca/lib/proca/org.ex
@@ -45,6 +45,7 @@ defmodule Proca.Org do
     field :custom_action_confirm, :boolean, default: false
     field :custom_action_deliver, :boolean, default: false
     field :system_sqs_deliver, :boolean, default: false
+    field :custom_event_deliver, :boolean, default: false
 
     belongs_to :event_backend, Proca.Service
     # for system events from Proca.Server.Notify

--- a/proca/lib/proca/pipes/supervisor.ex
+++ b/proca/lib/proca/pipes/supervisor.ex
@@ -51,6 +51,7 @@ defmodule Proca.Pipes.Supervisor do
   def reload_child(org = %Org{}) do
     case Pipes.Topology.whereis(org) do
       nil ->
+        info("Org processing starting for #{org.name} (#{org.id})")
         start_child(org)
 
       pid ->

--- a/proca/lib/proca/pipes/topology.ex
+++ b/proca/lib/proca/pipes/topology.ex
@@ -59,7 +59,7 @@ defmodule Proca.Pipes.Topology do
 
   - Worker queues, are enabled by flags on Org (boolean columns):
     - `system_sqs_deliver` sends to SQS (SQS service must be configured)
-    - `email.supporter` sends double-opt-in email when: `email_opt_in` is TRUE, and `email_opt_in_template` is set on Org. Org must have email/template backends set.
+    - `email.supporter` sends double-opt-in email when: `supporter_confirm` is `true`. Org must have email/template backends set. The email will be set if `email_supporter_template` is set on org or action page.
     - `email.supporter` sends thank you emails when Org has email/template backends set. The worker will send emails if ActionPage.thank_you_tempalte_ref refers to template identifier in the backend.
 
 
@@ -117,9 +117,7 @@ defmodule Proca.Pipes.Topology do
 
   def configuration(o = %Org{}) do
     %{
-      confirm_supporter:
-        Stage.EmailSupporter.start_for?(o) and o.email_opt_in and
-          is_bitstring(o.email_opt_in_template),
+      confirm_supporter: Stage.EmailSupporter.start_for?(o) and o.supporter_confirm,
       email_supporter: Stage.EmailSupporter.start_for?(o),
       sqs: Stage.SQS.start_for?(o),
       webhook: Stage.Webhook.start_for?(o)

--- a/proca/lib/proca/schema.ex
+++ b/proca/lib/proca/schema.ex
@@ -36,22 +36,22 @@ defmodule Proca.Schema do
       def all(query, [{:one, true}]), do: Repo.one(query)
       def all(query, [{:one!, true}]), do: Repo.one!(query)
 
-      def all(query, [{:id, id} | kw]) do
+      def all(query, [{:id, id} | kw]) when is_number(id) do
         import Ecto.Query, only: [where: 3]
         where(query, [a], a.id == ^id) |> all(kw)
       end
 
-      def all(query, [{:preload, assocs} | kw]) do
+      def all(query, [{:preload, assocs} | kw]) when is_list(assocs) do
         import Ecto.Query, only: [preload: 3]
         preload(query, [a], ^assocs) |> all(kw)
       end
 
-      def all(query, [{:order_by, order} | kw]) do
+      def all(query, [{:order_by, order} | kw]) when is_list(order) do
         import Ecto.Query, only: [order_by: 3]
         order_by(query, [a], ^order) |> all(kw)
       end
 
-      def all(query, [{:limit, limit} | kw]) do
+      def all(query, [{:limit, limit} | kw]) when is_number(limit) do
         import Ecto.Query, only: [limit: 3]
         limit(query, [a], ^limit) |> all(kw)
       end

--- a/proca/lib/proca/service/email_backend.ex
+++ b/proca/lib/proca/service/email_backend.ex
@@ -35,11 +35,11 @@ defmodule Proca.Service.EmailBackend do
 
   @type recipient :: %EmailRecipient{}
 
-  @callback put_recipient(email :: %Email{}, recipients :: [recipient]) :: %Email{}
+  @callback put_recipient(email :: %Email{}, recipients :: recipient) :: %Email{}
   @callback put_template(email :: %Email{}, template :: %EmailTemplate{}) :: %Email{}
   @callback put_reply_to(email :: %Email{}, reply_to_email :: String.t()) :: %Email{}
   @callback put_custom_id(email :: %Email{}, custom_id :: String.t()) :: %Email{}
-  @callback deliver(%Email{}, %Org{}) :: any()
+  @callback deliver([%Email{}], %Org{}) :: any()
 
   @callback handle_bounce(params :: any()) :: any()
 

--- a/proca/lib/proca/service/email_template.ex
+++ b/proca/lib/proca/service/email_template.ex
@@ -4,4 +4,28 @@ defmodule Proca.Service.EmailTemplate do
   """
 
   defstruct [:name, :subject, :html, :text, :ref]
+
+  @doc """
+  Validate the template set in changeset is valid for :org of this entity.
+  If no template backend is configured, return success - we assume that user might use an external template names in the AP.
+  """
+  def validate_exists(%Ecto.Changeset{} = changeset, field) do
+    alias Proca.Service.EmailTemplateDirectory
+    alias Ecto.Changeset
+    alias Proca.Org
+
+    Changeset.validate_change(changeset, field, fn f, template ->
+      org =
+        case Changeset.apply_changes(changeset) do
+          %{org: %Org{}} = o -> o
+          %{org_id: org_id} -> Org.one(id: org_id)
+        end
+
+      case EmailTemplateDirectory.ref_by_name_reload(org, template) do
+        {:ok, _} -> []
+        :not_configured -> []
+        :not_found -> [{f, "Template not found"}]
+      end
+    end)
+  end
 end

--- a/proca/lib/proca/service/email_template_directory.ex
+++ b/proca/lib/proca/service/email_template_directory.ex
@@ -113,12 +113,18 @@ defmodule Proca.Service.EmailTemplateDirectory do
     :not_configured
   end
 
-  def list_names(%Org{template_backend_id: bid}) do
+  def list_names(org = %Org{template_backend_id: bid}) when is_number(bid) do
+    load_templates_sync(org)
+
     spec =
       fun do
         {{id, ref}, %{name: n}} when id == ^bid -> n
       end
 
     :ets.select(table_name(), spec)
+  end
+
+  def list_names(_) do
+    :not_configured
   end
 end

--- a/proca/lib/proca/service/mailjet.ex
+++ b/proca/lib/proca/service/mailjet.ex
@@ -17,7 +17,7 @@ defmodule Proca.Service.Mailjet do
   @behaviour Proca.Service.EmailBackend
 
   alias Proca.{Org, Service, Supporter, Target}
-  alias Proca.Service.{EmailTemplate, EmailBackend}
+  alias Proca.Service.{EmailTemplate, EmailBackend, EmailRecipient}
   alias Swoosh.Adapters.Mailjet
   alias Swoosh.Email
   import Logger
@@ -66,7 +66,7 @@ defmodule Proca.Service.Mailjet do
   end
 
   @impl true
-  def put_recipient(email, recipient) do
+  def put_recipient(email, %EmailRecipient{} = recipient) do
     email
     |> Email.to({recipient.first_name, recipient.email})
     |> Email.put_provider_option(:variables, recipient.fields)
@@ -105,7 +105,7 @@ defmodule Proca.Service.Mailjet do
   end
 
   @impl true
-  def deliver(emails, %Org{email_backend: srv}) do
+  def deliver(emails, %Org{email_backend: srv}) when is_list(emails) do
     case Mailjet.deliver_many(emails, config(srv)) do
       {:ok, _} ->
         :ok
@@ -136,7 +136,7 @@ defmodule Proca.Service.Mailjet do
 
   defp parse_type(["action" | [tail | _]]), do: {:action, tail}
   defp parse_type(["target" | [tail | _]]), do: {:target, tail}
-  defp parse_type(args), do: {:empty, nil}
+  defp parse_type(_args), do: {:empty, nil}
 
   def config(%Service{name: :mailjet, user: u, password: p}) do
     %{

--- a/proca/lib/proca/stage/event.ex
+++ b/proca/lib/proca/stage/event.ex
@@ -1,5 +1,5 @@
 defmodule Proca.Stage.Event do
-  alias Proca.{Confirm, Org}
+  alias Proca.{Confirm, Org, Supporter}
   alias Proca.Pipes.Connection
   import Proca.Stage.Support, only: [camel_case_keys: 1]
 
@@ -10,7 +10,56 @@ defmodule Proca.Stage.Event do
 
     data =
       Confirm.notify_fields(confirm)
-      |> Map.merge(meta)
+      |> put_meta(meta)
+      |> camel_case_keys()
+
+    Connection.publish(exchange_for(org_id), routing_key, data)
+  end
+
+  def emit(:supporter_updated, %Supporter{} = supporter, org_id) when is_number(org_id) do
+    alias Proca.Stage.MessageV2
+    alias Proca.Action
+
+    routing_key = "supporter_updated"
+    meta = %{event_type: "supporter_updated"}
+
+    contact_by_org_id = fn
+      %{org_id: ^org_id} -> true
+      _ -> false
+    end
+
+    contact = Enum.find(supporter.contacts, contact_by_org_id)
+
+    data =
+      %{
+        contact: MessageV2.contact_data(supporter, contact),
+        privacy: MessageV2.contact_privacy(%Action{with_consent: true}, contact)
+      }
+      |> put_meta(meta)
+      |> camel_case_keys()
+
+    Connection.publish(exchange_for(org_id), routing_key, data)
+  end
+
+  def emit(:campaign_updated, campaign, org_id) do
+    routing_key = "campaign_updated"
+    meta = %{event_type: "campaign_updated"}
+
+    campaign = campaign |> Proca.Repo.preload([:org])
+
+    data =
+      campaign
+      |> Map.from_struct()
+      |> Map.take([:id, :name, :external_id, :title, :config, :contact_schema])
+      |> Map.merge(%{
+        campaign_id: campaign.id,
+        org_id: campaign.org.id,
+        org: %{
+          name: campaign.org.name,
+          title: campaign.org.title
+        }
+      })
+      |> put_meta(meta)
       |> camel_case_keys()
 
     Connection.publish(exchange_for(org_id), routing_key, data)
@@ -18,5 +67,11 @@ defmodule Proca.Stage.Event do
 
   defp exchange_for(org_id) when is_number(org_id) do
     Proca.Pipes.Topology.xn(%Org{id: org_id}, "event")
+  end
+
+  defp put_meta(payload, meta) do
+    payload
+    |> Map.merge(meta)
+    |> Map.put(:schema, "proca:event:2")
   end
 end

--- a/proca/lib/proca/stage/message_v1.ex
+++ b/proca/lib/proca/stage/message_v1.ex
@@ -123,7 +123,8 @@ defmodule Proca.Stage.MessageV1 do
       "actionPage" => %{
         "locale" => action.action_page.locale,
         "name" => action.action_page.name,
-        "thankYouTemplateRef" => action.action_page.thank_you_template_ref
+        "thankYouTemplate" => action.action_page.thank_you_template,
+        "thankYouTemplateRef" => action_page_template_ref(action.action_page)
       },
       "campaign" => %{
         "name" => action.campaign.name,
@@ -161,4 +162,13 @@ defmodule Proca.Stage.MessageV1 do
   end
 
   def put_action_donation(action_map, donation) when is_nil(donation), do: action_map
+
+  def action_page_template_ref(action_page) do
+    alias Proca.Service.EmailTemplateDirectory
+
+    case EmailTemplateDirectory.ref_by_name(action_page.org, action_page.thank_you_template) do
+      {:ok, ref} -> ref
+      _ -> nil
+    end
+  end
 end

--- a/proca/lib/proca/stage/message_v2.ex
+++ b/proca/lib/proca/stage/message_v2.ex
@@ -44,7 +44,7 @@ defmodule Proca.Stage.MessageV2 do
         |> MessageV1.put_action_donation(action.donation),
       "contact" => contact_data(action.supporter, contact),
       "personalInfo" => personal_info_data(contact),
-      "privacy" => contact_privacy(action, contact),
+      "privacy" => contact_privacy(action.supporter, contact, action.with_consent),
       "tracking" => MessageV1.tracking_data(action)
     }
     |> put_action_meta(stage)
@@ -102,16 +102,43 @@ defmodule Proca.Stage.MessageV2 do
     }
   end
 
-  def contact_privacy(%Action{with_consent: true}, contact = %Contact{}) do
-    %{
-      "optIn" => contact.communication_consent,
-      "givenAt" => contact.inserted_at |> Support.to_iso8601()
+  def contact_privacy(supporter, contact, new_consent \\ true)
+
+  def contact_privacy(
+        %Supporter{
+          email_status: email_status,
+          email_status_changed: email_status_changed
+        },
+        contact = %Contact{},
+        new_consent
+      ) do
+    p = %{
+      "emailStatus" =>
+        if email_status == :none do
+          nil
+        else
+          Atom.to_string(email_status)
+        end,
+      "emailStatusChanged" =>
+        if email_status_changed != nil do
+          Support.to_iso8601(email_status_changed)
+        else
+          nil
+        end
     }
+
+    if new_consent do
+      %{
+        "optIn" => contact.communication_consent,
+        "givenAt" => contact.inserted_at |> Support.to_iso8601()
+      }
+      |> Map.merge(p)
+    else
+      p
+    end
   end
 
-  def contact_privacy(%Action{with_consent: false}, %Contact{}), do: nil
-
-  def contact_privacy(%Action{}, nil), do: nil
+  def contact_privacy(_, nil, _), do: nil
 
   def put_action_meta(map, stage) do
     map

--- a/proca/lib/proca/stage/message_v2.ex
+++ b/proca/lib/proca/stage/message_v2.ex
@@ -25,7 +25,8 @@ defmodule Proca.Stage.MessageV2 do
       "actionPage" => %{
         "locale" => action.action_page.locale,
         "name" => action.action_page.name,
-        "thankYouTemplateRef" => action.action_page.thank_you_template_ref
+        "thankYouTemplate" => action.action_page.thank_you_template,
+        "thankYouTemplateRef" => MessageV1.action_page_template_ref(action.action_page)
       },
       "campaignId" => action.campaign_id,
       "campaign" => %{

--- a/proca/lib/proca/stage/support.ex
+++ b/proca/lib/proca/stage/support.ex
@@ -18,7 +18,7 @@ defmodule Proca.Stage.Support do
       where: a.id in ^action_ids,
       preload: [
         [supporter: [contacts: [:public_key, :sign_key, :org]]],
-        :action_page,
+        [action_page: :org],
         :campaign,
         :source
       ]

--- a/proca/lib/proca/stage/webhook.ex
+++ b/proca/lib/proca/stage/webhook.ex
@@ -98,6 +98,10 @@ defmodule Proca.Stage.Webhook do
           error("Webhook returned 404 Not found: #{webhook.host}")
           Message.failed(msg, "Not found")
 
+        {:ok, code} ->
+          error("Webhook returned #{code} code: #{webhook.host}")
+          Message.failed(msg, "Code #{code}")
+
         {:error, reason} ->
           error("Webhook failed: #{inspect(reason)}: #{webhook.host}")
           Message.failed(msg, reason)

--- a/proca/lib/proca/stage/webhook.ex
+++ b/proca/lib/proca/stage/webhook.ex
@@ -18,7 +18,7 @@ defmodule Proca.Stage.Webhook do
   import Proca.Stage.Support, only: [ignore: 1, ignore: 2, supporter_link: 3]
 
   @doc "Get selected webhook service"
-  def get_service(org = %{event_backend_id: id}) do
+  def get_service(org = %{event_backend_id: id}) when is_number(id) do
     Service.one(org: org, id: id, name: :webhook)
   end
 

--- a/proca/lib/proca/supporter.ex
+++ b/proca/lib/proca/supporter.ex
@@ -9,6 +9,7 @@ defmodule Proca.Supporter do
   alias Proca.{Supporter, Contact, ActionPage}
   alias Proca.Contact.Data
   alias Proca.Supporter.Privacy
+  alias Proca.Stage.Support
   import Ecto.Changeset
 
   schema "supporters" do
@@ -32,7 +33,6 @@ defmodule Proca.Supporter do
     timestamps()
   end
 
-  @doc false
   def changeset(supporter, attrs) do
     ch =
       supporter

--- a/proca/lib/proca/supporter.ex
+++ b/proca/lib/proca/supporter.ex
@@ -39,8 +39,11 @@ defmodule Proca.Supporter do
       |> cast(attrs, [:email_status])
 
     case ch.changes do
-      %{email_status: _} -> change(ch, email_status_changed: NaiveDateTime.utc_now())
-      _ -> ch
+      %{email_status: _} ->
+        change(ch, email_status_changed: NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second))
+
+      _ ->
+        ch
     end
   end
 

--- a/proca/lib/proca/supporter/privacy.ex
+++ b/proca/lib/proca/supporter/privacy.ex
@@ -62,49 +62,37 @@ defmodule Proca.Supporter.Privacy do
   @spec consents(%ActionPage{}, %Privacy{}) :: [%Consent{}]
   def consents(action_page = %ActionPage{}, privacy = %Privacy{}) when not is_nil(action_page) do
     action_page = Proca.Repo.preload(action_page, [:org, campaign: :org])
-    widget_delivery = action_page.delivery
 
-    # lead org delivers, if widget org doesn't, or if it overrides it
+    is_split = action_page.campaign.org_id != action_page.org_id
+
+    # when not splitting, collector is processor, also when it delivers
+    widget_delivery = not is_split or action_page.delivery
+
     lead_delivery = not widget_delivery or action_page.campaign.force_delivery
-
-    is_lead = action_page.campaign.org_id != action_page.org_id
 
     widget_communication = privacy.opt_in
     lead_communication = privacy.lead_opt_in
 
-    widget_org =
-      cond do
-        widget_delivery or widget_communication ->
-          [
-            %Consent{
-              org: action_page.org,
-              communication_consent: widget_communication,
-              communication_scopes: @default_communication_scopes,
-              delivery_consent: widget_delivery
-            }
-          ]
+    collector_consent = %Consent{
+      org: action_page.org,
+      communication_consent: widget_communication,
+      communication_scopes: @default_communication_scopes,
+      delivery_consent: widget_delivery
+    }
 
-        true ->
-          []
-      end
+    lead_consent = %Consent{
+      org: action_page.campaign.org,
+      communication_consent: lead_communication,
+      communication_scopes: @default_communication_scopes,
+      delivery_consent: lead_delivery
+    }
 
-    lead_org =
-      cond do
-        is_lead and (lead_delivery or lead_communication) and action_page.live ->
-          [
-            %Consent{
-              org: action_page.campaign.org,
-              communication_consent: lead_communication,
-              communication_scopes: @default_communication_scopes,
-              delivery_consent: lead_delivery
-            }
-          ]
-
-        true ->
-          []
-      end
-
-    widget_org ++ lead_org
+    if action_page.live do
+      [collector_consent, lead_consent]
+    else
+      [collector_consent]
+    end
+    |> Enum.filter(fn %{delivery_consent: dc, communication_consent: cc} -> dc or cc end)
   end
 
   def cleartext_fields(%ActionPage{org: %Org{high_security: true}}) do

--- a/proca/lib/proca_web/resolvers/org.ex
+++ b/proca/lib/proca_web/resolvers/org.ex
@@ -73,13 +73,13 @@ defmodule ProcaWeb.Resolvers.Org do
 
     email_service =
       case org do
-        %{email_backend: %{name: name}} -> name
+        %Org{email_backend: %{name: name}} -> name
         _ -> nil
       end
 
     event_service =
       case org do
-        %{event_service: %{name: name}} -> name
+        %Org{event_backend: %{name: name}} -> name
         _ -> nil
       end
 

--- a/proca/lib/proca_web/resolvers/org.ex
+++ b/proca/lib/proca_web/resolvers/org.ex
@@ -61,8 +61,8 @@ defmodule ProcaWeb.Resolvers.Org do
       :ok,
       Map.take(org, [
         :contact_schema,
-        :email_opt_in,
-        :email_opt_in_template,
+        :supporter_confirm,
+        :supporter_confirm_template,
         :high_security
       ])
     }

--- a/proca/lib/proca_web/resolvers/org.ex
+++ b/proca/lib/proca_web/resolvers/org.ex
@@ -85,6 +85,7 @@ defmodule ProcaWeb.Resolvers.Org do
 
     {:ok,
      %{
+       org: org,
        email_from: org.email_from,
        email_backend: email_service,
        custom_supporter_confirm: org.custom_supporter_confirm,
@@ -95,6 +96,13 @@ defmodule ProcaWeb.Resolvers.Org do
        event_backend: event_service,
        confirm_processing: org.confirm_processing
      }}
+  end
+
+  def org_processing_templates(%{org: org}, _, _) do
+    case Proca.Service.EmailTemplateDirectory.list_names(org) do
+      :not_configured -> {:ok, nil}
+      lst -> {:ok, lst}
+    end
   end
 
   def update_org_processing(_, args, %{context: %{org: org}}) do

--- a/proca/lib/proca_web/router.ex
+++ b/proca/lib/proca_web/router.ex
@@ -55,7 +55,7 @@ defmodule ProcaWeb.Router do
     pipe_through [:api]
 
     get "/s/:action_id/:verb/:ref", ProcaWeb.ConfirmController, :supporter
-    get "/ok/:org_id/:action_id", ProcaWeb.ConfirmController, :double_opt_in
+    get "/d/:action_id/:ref", ProcaWeb.ConfirmController, :double_opt_in
     get "/:verb/:code", ProcaWeb.ConfirmController, :confirm
     # get "/a/:action_id/:ref/:verb/:code", ProcaWeb.ConfirmController, :confirm_code
   end

--- a/proca/lib/proca_web/schema/action_page_types.ex
+++ b/proca/lib/proca_web/schema/action_page_types.ex
@@ -30,8 +30,15 @@ defmodule ProcaWeb.Schema.ActionPageTypes do
     field :locale, non_null(:string)
     @desc "Name where the widget is hosted"
     field :name, non_null(:string)
-    @desc "Reference to thank you email templated of this Action Page"
-    field :thank_you_template_ref, :string
+    @desc "Thank you email templated of this Action Page"
+    field :thank_you_template, :string
+    @desc "A reference to thank you email template of this ActionPage"
+    field :thank_you_template_ref, :string do
+      resolve(fn ap, _, _ ->
+        Proca.ActionPage.thank_you_template_ref(ap)
+      end)
+    end
+
     @desc "Is live?"
     field :live, non_null(:boolean)
     @desc "List of steps in journey (DEPRECATED: moved under config)"
@@ -246,8 +253,8 @@ defmodule ProcaWeb.Schema.ActionPageTypes do
     @desc "2-letter, lowercase, code of ActionPage language"
     field :locale, :string
 
-    @desc "A reference to thank you email template of this ActionPage"
-    field :thank_you_template_ref, :string
+    @desc "Thank you email template of this ActionPage"
+    field :thank_you_template, :string
 
     @desc """
     Extra supporter count. If you want to add a number of signatories you have offline or kept in another system, you can specify the number here.

--- a/proca/lib/proca_web/schema/org_types.ex
+++ b/proca/lib/proca_web/schema/org_types.ex
@@ -337,5 +337,9 @@ defmodule ProcaWeb.Schema.OrgTypes do
     field :event_backend, :service_name
     field :event_processing, non_null(:boolean)
     field :confirm_processing, non_null(:boolean)
+
+    field :email_templates, list_of(non_null(:string)) do
+      resolve(&ProcaWeb.Resolvers.Org.org_processing_templates/3)
+    end
   end
 end

--- a/proca/lib/proca_web/schema/org_types.ex
+++ b/proca/lib/proca_web/schema/org_types.ex
@@ -144,10 +144,10 @@ defmodule ProcaWeb.Schema.OrgTypes do
     field :contact_schema, :contact_schema
 
     @desc "Email opt in enabled"
-    field :email_opt_in, :boolean
+    field :supporter_confirm, :boolean
 
     @desc "Email opt in template name"
-    field :email_opt_in_template, :string
+    field :supporter_confirm_template, :string
 
     @desc "Config"
     field :config, :json
@@ -259,10 +259,10 @@ defmodule ProcaWeb.Schema.OrgTypes do
     field :contact_schema, non_null(:contact_schema)
 
     @desc "Email opt in enabled"
-    field :email_opt_in, non_null(:boolean)
+    field :supporter_confirm, non_null(:boolean)
 
     @desc "Email opt in template name"
-    field :email_opt_in_template, :string
+    field :supporter_confirm_template, :string
 
     @desc "High data security enabled"
     field :high_security, non_null(:boolean)

--- a/proca/priv/repo/migrations/20211222205257_named_action_page_templates.exs
+++ b/proca/priv/repo/migrations/20211222205257_named_action_page_templates.exs
@@ -1,0 +1,48 @@
+defmodule Proca.Repo.Migrations.NamedActionPageTemplates do
+  use Ecto.Migration
+
+  def up do
+    rename table(:orgs), :email_opt_in, to: :supporter_confirm
+    rename table(:orgs), :email_opt_in_template, to: :supporter_confirm_template
+
+    rename table(:action_pages), :thank_you_template_ref, to: :thank_you_template
+
+    alter table(:action_pages) do
+      add :supporter_confirm_template, :string, null: true
+    end
+  end
+
+  def down do
+    rename table(:orgs), :supporter_confirm, to: :email_opt_in
+    rename table(:orgs), :supporter_confirm_template, to: :email_opt_in_template
+
+    rename table(:action_pages), :thank_you_template, to: :thank_you_template_ref
+
+    alter table(:action_pages) do
+      remove :supporter_confirm_template
+    end
+  end
+
+  def template_ref_to_name do
+    import Ecto.Query
+
+    action_pages =
+      Proca.Repo.all(from(o in Proca.ActionPage, preload: [org: [template_backend: :org]]))
+
+    for ap <- action_pages, ap.org.template_backend != nil do
+      o = ap.org.template_backend.org
+      Proca.Service.EmailTemplateDirectory.load_templates_sync(o)
+
+      case ap.thank_you_template do
+        nil ->
+          nil
+
+        ref ->
+          case Proca.Service.EmailTemplateDirectory.name_by_ref(o, String.to_integer(ref)) do
+            {:ok, name} -> Proca.Repo.update!(Ecto.Changeset.change(ap, thank_you_template: name))
+            _ -> throw("Action Page #{ap.name} (#{ap.id}): cannot find template name for #{ref}")
+          end
+      end
+    end
+  end
+end

--- a/proca/priv/repo/migrations/20220103165519_add_custom_event_deliver_to_orgs.exs
+++ b/proca/priv/repo/migrations/20220103165519_add_custom_event_deliver_to_orgs.exs
@@ -1,0 +1,9 @@
+defmodule Proca.Repo.Migrations.AddCustomEventDeliverToOrgs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:orgs) do
+      add :custom_event_deliver, :boolean, default: false, null: false
+    end
+  end
+end

--- a/proca/test/proca/auth_test.exs
+++ b/proca/test/proca/auth_test.exs
@@ -1,0 +1,47 @@
+defmodule Proca.AuthTest do
+  use Proca.DataCase
+  import Proca.StoryFactory, only: [red_story: 0]
+  alias Proca.Auth
+
+  setup do
+    red_story()
+  end
+
+  test "resolve staffer for red user", %{
+    red_org: org,
+    red_ap: ap,
+    red_user: user,
+    yellow_org: org2,
+    red_campaign: camp
+  } do
+    user_id = user.id
+
+    assert %Auth{
+             staffer: %Proca.Staffer{user_id: ^user_id},
+             user: ^user
+           } = Auth.get_for_user(org, user)
+
+    assert %Auth{
+             staffer: %Proca.Staffer{user_id: ^user_id},
+             user: ^user
+           } = Auth.get_for_user(camp, user)
+  end
+
+  test "resolve staffer for yellow user by campaign", %{
+    yellow_campaign: camp,
+    yellow_user: user,
+    yellow_ap: ap
+  } do
+    user_id = user.id
+
+    assert %Auth{
+             staffer: %Proca.Staffer{user_id: ^user_id},
+             user: ^user
+           } = Auth.get_for_user(camp, user)
+
+    assert %Auth{
+             staffer: %Proca.Staffer{user_id: ^user_id},
+             user: ^user
+           } = Auth.get_for_user(ap, user)
+  end
+end

--- a/proca/test/proca_web/api/action_test.exs
+++ b/proca/test/proca_web/api/action_test.exs
@@ -27,7 +27,6 @@ defmodule ProcaWeb.Api.ActionTest do
   end
 
   def action_with_contact(
-        _org,
         ap,
         action_info,
         contact_info,
@@ -133,7 +132,6 @@ defmodule ProcaWeb.Api.ActionTest do
   test "create stripe donation action", %{org: org, pages: [ap]} do
     {:ok, %{contact_ref: ref}} =
       action_with_contact(
-        org,
         ap,
         %{
           action_type: "stripe-donation",
@@ -175,7 +173,6 @@ defmodule ProcaWeb.Api.ActionTest do
   test "create action with location tracking", %{org: org, pages: [ap]} do
     {:ok, result} =
       action_with_contact(
-        org,
         ap,
         %{action_type: "x"},
         %{first_name: "Jan", email: "j@a.n"},

--- a/proca/test/proca_web/api/double_opt_in_test.exs
+++ b/proca/test/proca_web/api/double_opt_in_test.exs
@@ -1,0 +1,201 @@
+defmodule ProcaWeb.Api.DoubleOptInTest do
+  use ProcaWeb.ConnCase
+  import Proca.StoryFactory, only: [blue_story: 0]
+  import Ecto.Query
+  import Ecto.Changeset
+  alias Proca.Factory
+
+  use Proca.TestEmailBackend
+
+  alias Proca.{Repo, Action, Supporter}
+
+  @basic_data %{}
+
+  setup do
+    assert Proca.Pipes.Connection.is_connected?()
+
+    %{
+      proc: Proca.Server.Processing.start_link([])
+    }
+  end
+
+  describe "Double opt in" do
+    setup ctx do
+      story =
+        blue_story()
+        |> Map.merge(ctx)
+    end
+
+    test "for action with opt_in", %{conn: conn, pages: [ap]} do
+      {ref, email} = add_action_contact(ap, true)
+
+      s = check_supporter(ref, status: :accepted, email_status: :none, consent: {true, true})
+      a = check_action(s, status: :delivered)
+
+      click_doi_link(conn, %{a | supporter: s}, "y")
+
+      s =
+        check_supporter(ref,
+          status: :accepted,
+          email_status: :double_opt_in,
+          consent: {true, true}
+        )
+
+      a = check_action(s, status: :delivered)
+    end
+  end
+
+  describe "Supporter confirm action:" do
+    setup ctx do
+      story = blue_story()
+
+      %{
+        story
+        | org:
+            Repo.update!(
+              change(story.org,
+                supporter_confirm: true,
+                supporter_confirm_template: "confirm_your_signature"
+              )
+            )
+      }
+      |> Map.merge(ctx)
+    end
+
+    test "Confirm but not double opt in", %{conn: conn, pages: [ap]} do
+      {ref, email} = add_action_contact(ap, false)
+
+      s = check_supporter(ref, status: :confirming, email_status: :none, consent: {true, false})
+      a = check_action(s, status: :new)
+
+      click_supporter_link(conn, %{a | supporter: s}, :confirm)
+
+      s = check_supporter(ref, status: :accepted, email_status: :none, consent: {true, false})
+      a = check_action(s, status: :delivered)
+    end
+
+    test "Confirm but do double opt in", %{conn: conn, pages: [ap]} do
+      {ref, email} = add_action_contact(ap, false)
+
+      s = check_supporter(ref, status: :confirming, email_status: :none, consent: {true, false})
+      a = check_action(s, status: :new)
+
+      click_supporter_link(conn, %{a | supporter: s}, :confirm, "doi=1")
+
+      s =
+        check_supporter(ref,
+          status: :accepted,
+          email_status: :double_opt_in,
+          consent: {true, false}
+        )
+
+      a = check_action(s, status: :delivered)
+    end
+
+    test "Confirm but do form opt in and double opt in", %{conn: conn, pages: [ap]} do
+      {ref, email} = add_action_contact(ap, true)
+
+      s = check_supporter(ref, status: :confirming, email_status: :none, consent: {true, true})
+      a = check_action(s, status: :new)
+
+      click_supporter_link(conn, %{a | supporter: s}, :confirm, "doi=1")
+
+      s =
+        check_supporter(ref,
+          status: :accepted,
+          email_status: :double_opt_in,
+          consent: {true, true}
+        )
+
+      a = check_action(s, status: :delivered)
+    end
+
+    test "Reject and not double opt in", %{conn: conn, pages: [ap]} do
+      {ref, email} = add_action_contact(ap, false)
+
+      s = check_supporter(ref, status: :confirming, email_status: :none, consent: {true, false})
+      a = check_action(s, status: :new)
+
+      click_supporter_link(conn, %{a | supporter: s}, :reject)
+
+      s = check_supporter(ref, status: :rejected, email_status: :none, consent: {true, false})
+      a = check_action(s, status: :new)
+
+      # after process old kicks in...
+      Proca.Server.Processing.process(a)
+      s = check_supporter(ref, status: :rejected, email_status: :none, consent: {true, false})
+      a = check_action(s, status: :rejected)
+    end
+  end
+
+  # ----------- HELPERS -------------------
+  #
+  def check_supporter(ref, status: status, email_status: es, consent: {dc, cc}) do
+    added =
+      Supporter.one(
+        contact_ref: ref,
+        limit: 1,
+        order_by: [desc: :id],
+        preload: [:actions, :contacts]
+      )
+
+    assert added.processing_status == status
+    assert [%{delivery_consent: dc, communication_consent: cc}] = added.contacts
+    assert added.email_status == es
+
+    added
+  end
+
+  def check_action(supporter, status: status) do
+    [act] = supporter.actions
+    assert act.processing_status == status
+
+    %{act | supporter: supporter}
+  end
+
+  def click_doi_link(conn, action, doi) do
+    refbase = Supporter.base_encode(action.supporter.fingerprint)
+    link = "/link/d/#{action.id}/#{refbase}"
+    link = link <> "?redir=https://landingpage.com"
+    res = get(conn, link, %{})
+    Proca.Server.Processing.sync()
+  end
+
+  def click_supporter_link(conn, action, verb, qa \\ nil) do
+    link = Proca.Stage.Support.supporter_link(action, verb)
+    # strip http://localhost
+    link =
+      "/" <>
+        (link |> String.split("/") |> Enum.slice(3..-1) |> Enum.join("/")) <>
+        "?redir=https://landingpage.com"
+
+    link = link <> if qa == nil, do: "", else: "&" <> qa
+    res = get(conn, link, %{})
+    Proca.Server.Processing.sync()
+  end
+
+  def add_action_contact(ap, opt_in) do
+    contact =
+      Map.from_struct(Factory.build(:basic_data_pl))
+      |> Map.delete(:name)
+
+    {:ok, %{contact_ref: ref}} =
+      ProcaWeb.Resolvers.Action.add_action_contact(
+        :none,
+        %{
+          action_page_id: ap.id,
+          action: %{
+            action_type: "register"
+          },
+          contact: contact,
+          privacy: %{opt_in: opt_in}
+        },
+        %{context: %{}, extensions: %{}}
+      )
+
+    Proca.Server.Processing.sync()
+
+    {:ok, ref2} = Supporter.base_decode(ref)
+    {ref2, contact.email}
+  end
+end

--- a/proca/test/proca_web/api/partner_join_campaign_test.exs
+++ b/proca/test/proca_web/api/partner_join_campaign_test.exs
@@ -30,8 +30,8 @@ defmodule ProcaWeb.PartnerJoinCampaignTest do
         id
         personalData {
           contactSchema
-          emailOptIn
-          emailOptInTemplate
+          supporterConfirm
+          supporterConfirmTemplate
         }
       }
 

--- a/proca/test/server/stats_test.exs
+++ b/proca/test/server/stats_test.exs
@@ -10,7 +10,7 @@ defmodule Proca.Server.StatsTest do
   import Ecto.Query
 
   setup do
-    red_story
+    red_story()
   end
 
   test "Signed second campaign with just action", %{

--- a/proca/test/story_factory_test.exs
+++ b/proca/test/story_factory_test.exs
@@ -1,0 +1,61 @@
+defmodule Proca.StoryFactoryTest do
+  use Proca.DataCase
+  import Proca.StoryFactory
+
+  describe "Red Story" do
+    setup do
+      red_story()
+    end
+
+    test "Red org tree", %{
+      red_org: org,
+      red_campaign: camp,
+      red_user: user,
+      red_owner: staffer,
+      red_ap: ap
+    } do
+      assert org.id == staffer.org_id
+      assert user.id == staffer.user_id
+      assert camp.org_id == org.id
+      assert ap.org_id == org.id
+    end
+
+    test "Yellow org tree", %{
+      yellow_org: org,
+      yellow_campaign: camp,
+      yellow_user: user,
+      yellow_owner: staffer,
+      yellow_ap: ap
+    } do
+      assert org.id == staffer.org_id
+      assert user.id == staffer.user_id
+      assert camp.org_id == org.id
+      assert ap.org_id == org.id
+    end
+
+    test "Partner APs", %{
+      orange_aps: [ap1, ap2],
+      yellow_campaign: camp,
+      red_org: partner
+    } do
+      assert ap1.org_id == partner.id
+      assert ap2.org_id == partner.id
+      assert ap1.campaign_id == camp.id
+      assert ap2.campaign_id == camp.id
+    end
+  end
+
+  describe "Blue Story" do
+    setup do
+      blue_story()
+    end
+
+    test "Blue org tree", %{
+      org: org,
+      pages: [ap]
+    } do
+      assert ap.org_id == org.id
+      assert Repo.one(Ecto.assoc(ap, :campaign)).org_id == org.id
+    end
+  end
+end

--- a/proca/test/support/factory.ex
+++ b/proca/test/support/factory.ex
@@ -87,8 +87,8 @@ defmodule Proca.Factory do
 
   def basic_data_pl_factory do
     %Proca.Contact.BasicData{
-      first_name: sequence("first_name"),
-      last_name: sequence("last_name"),
+      first_name: sequence("first_name", &"#{<<&1::utf8>>}aniel", start_at: ?A),
+      last_name: sequence("last_name", &"#{<<&1::utf8>>}ikiski", start_at: ?A),
       email: sequence("email", &"member-#{&1}@example.org"),
       phone: sequence("phone", ["+48123498213", "6051233412", "0048600919929"]),
       postcode: sequence("postcode", ["02-123", "03-999", "03-123", "33-123"]),

--- a/proca/test/support/test_email_backend.ex
+++ b/proca/test/support/test_email_backend.ex
@@ -189,4 +189,8 @@ defmodule Proca.TestEmailBackend do
 
     :ok
   end
+
+  @impl true
+  def handle_bounce(type) do
+  end
 end


### PR DESCRIPTION
Add a way to set `eventProcessing` on an org to receive events such as:
- supporter_updated
- campaign_updated
- confirm_created

The events can be passed to:
- webhook
- sqs
- deliver queue
If instance org has `eventProcessing` set, it will process all the events in the instance.