### PR TITLE
API token

### DIFF
--- a/proca/lib/proca/server/mtt_worker.ex
+++ b/proca/lib/proca/server/mtt_worker.ex
@@ -9,6 +9,8 @@ defmodule Proca.Server.MTTWorker do
 
   import Logger
 
+  @default_locale "en"
+
   def process_mtt_campaign(campaign) do
     campaign = Repo.preload(campaign, [:mtt, [org: :email_backend]])
 
@@ -180,7 +182,7 @@ defmodule Proca.Server.MTTWorker do
     action_pages_ids = Enum.map(msgs, fn m -> m.action.action_page_id end)
     action_pages = ActionPage.all(preload: [:org], by_ids: action_pages_ids) |> Enum.into(%{})
 
-    msgs_per_locale = Enum.group_by(msgs, & &1.target.locale)
+    msgs_per_locale = Enum.group_by(msgs, &(&1.target.locale || @default_locale))
 
     target_locales = Enum.uniq(Map.keys(msgs_per_locale))
 

--- a/proca/lib/proca/users/user_token.ex
+++ b/proca/lib/proca/users/user_token.ex
@@ -10,6 +10,7 @@ defmodule Proca.Users.UserToken do
   @reset_password_validity_in_days 1
   @confirm_validity_in_days 7
   @change_email_validity_in_days 7
+  @api_validity_in_days 365
   @session_validity_in_days 60
 
   schema "users_tokens" do
@@ -58,8 +59,18 @@ defmodule Proca.Users.UserToken do
     build_hashed_token(user, context, user.email)
   end
 
-  defp build_hashed_token(user, context, sent_to) do
-    token = :crypto.strong_rand_bytes(@rand_size)
+  @doc """
+  Create an API token.
+
+  We hash it so to avoid reconstruction. Valid for 1 year?
+  """
+  def build_api_token(user) do
+    # Prefix will base64 to API-
+    build_hashed_token(user, "api", nil, <<0, 242, 62>>)
+  end
+
+  defp build_hashed_token(user, context, sent_to, prefix \\ "") do
+    token = prefix <> :crypto.strong_rand_bytes(@rand_size)
     hashed_token = :crypto.hash(@hash_algorithm, token)
 
     {Base.url_encode64(token, padding: false),
@@ -97,6 +108,7 @@ defmodule Proca.Users.UserToken do
 
   defp days_for_context("confirm"), do: @confirm_validity_in_days
   defp days_for_context("reset_password"), do: @reset_password_validity_in_days
+  defp days_for_context("api"), do: @api_validity_in_days
 
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
@@ -111,6 +123,26 @@ defmodule Proca.Users.UserToken do
         query =
           from token in token_and_context_query(hashed_token, context),
             where: token.inserted_at > ago(@change_email_validity_in_days, "day")
+
+        {:ok, query}
+
+      :error ->
+        :error
+    end
+  end
+
+  def verify_user_token_query(token, context) do
+    case Base.url_decode64(token, padding: false) do
+      {:ok, decoded_token} ->
+        hashed_token = :crypto.hash(@hash_algorithm, decoded_token)
+
+        days = days_for_context(context)
+
+        query =
+          from token in token_and_context_query(hashed_token, context),
+            join: user in assoc(token, :user),
+            where: token.inserted_at > ago(^days, "day"),
+            select: user
 
         {:ok, query}
 
@@ -135,5 +167,9 @@ defmodule Proca.Users.UserToken do
 
   def user_and_contexts_query(user, [_ | _] = contexts) do
     from t in Proca.Users.UserToken, where: t.user_id == ^user.id and t.context in ^contexts
+  end
+
+  def expires_at(%Proca.Users.UserToken{inserted_at: i, context: c}) do
+    NaiveDateTime.add(i, days_for_context(c) * 24 * 60 * 60, :second)
   end
 end

--- a/proca/lib/proca_web/plugs/jwt_auth_plug.ex
+++ b/proca/lib/proca_web/plugs/jwt_auth_plug.ex
@@ -169,9 +169,10 @@ defmodule ProcaWeb.Plugs.JwtAuthPlug do
     UserAuth.assign_current_user(conn, user)
   end
 
+  # heuristic that jwt token must start with ey - base64 for {"
   defp get_token(conn, nil) do
     case Conn.get_req_header(conn, "authorization") do
-      ["Bearer " <> token] -> token
+      ["Bearer ey" <> token] -> "ey" <> token
       _ -> nil
     end
   end

--- a/proca/lib/proca_web/resolvers/user.ex
+++ b/proca/lib/proca_web/resolvers/user.ex
@@ -182,4 +182,19 @@ defmodule ProcaWeb.Resolvers.User do
 
     {:ok, User.all(criteria)}
   end
+
+  def api_token(user, _, %{context: %{auth: %Auth{user: user}}}) do
+    case Proca.Repo.one(Proca.Users.UserToken.user_and_contexts_query(user, ["api"])) do
+      nil ->
+        {:ok, nil}
+
+      token ->
+        {:ok,
+         %{
+           expires_at: Proca.Users.UserToken.expires_at(token)
+         }}
+    end
+  end
+
+  def api_token(_, _, _), do: {:ok, nil}
 end

--- a/proca/lib/proca_web/router.ex
+++ b/proca/lib/proca_web/router.ex
@@ -29,6 +29,7 @@ defmodule ProcaWeb.Router do
     plug CORSPlug
     plug ProcaWeb.Plugs.HeadersPlug, ["referer"]
     plug ProcaWeb.Plugs.BasicAuthPlug
+    plug ProcaWeb.Plugs.TokenAuthPlug
     plug ProcaWeb.Plugs.JwtAuthPlug
   end
 

--- a/proca/lib/proca_web/schema/user_types.ex
+++ b/proca/lib/proca_web/schema/user_types.ex
@@ -26,6 +26,10 @@ defmodule ProcaWeb.Schema.UserTypes do
     field :picture_url, :string
     field :job_title, :string
 
+    field :api_token, :api_token do
+      resolve(&Resolvers.User.api_token/3)
+    end
+
     field :is_admin, non_null(:boolean) do
       resolve(fn u, _, _ -> {:ok, can?(u, :instance_owner)} end)
     end
@@ -112,6 +116,14 @@ defmodule ProcaWeb.Schema.UserTypes do
       allow(:user)
       resolve(&Resolvers.User.update_user/3)
     end
+
+    field :reset_api_token, type: non_null(:string) do
+      allow(:user)
+
+      resolve(fn _, _, %{context: %{auth: %{user: user}}} ->
+        Proca.Users.reset_api_token(user)
+      end)
+    end
   end
 
   input_object :org_user_input do
@@ -146,5 +158,10 @@ defmodule ProcaWeb.Schema.UserTypes do
 
     @desc "Exact org name"
     field :org_name, :string
+  end
+
+  @desc "Api token metadata"
+  object :api_token do
+    field :expires_at, non_null(:naive_datetime)
   end
 end


### PR DESCRIPTION
Adds API token feature.

Usage:

- create token:
```
mutation CreateToken { resetApiToken }
```
returns new api token eg `API-XXXXXXXXXXXX`, valid 365 days.

- use the token:
put into authorization header: `Authorization: Bearer API-XXXXXXXXXXXXXXX` to authenticate calls.

