### PR TITLE
Implement user API token

### DIFF
--- a/proca/lib/proca/application.ex
+++ b/proca/lib/proca/application.ex
@@ -71,7 +71,8 @@ defmodule Proca.Application do
       {Proca.Stage.ProcessOld, Application.get_env(:proca, Proca)[:process_old_interval]},
       {Proca.ActionPage.Status, []},
       {Proca.Server.Jwks, Application.get_env(:proca, ProcaWeb.UserAuth)[:sso][:jwks_url]},
-      {Proca.Server.MTT, []}
+      {Proca.Server.MTT, []},
+      {Proca.Users.Status, [interval: 30_000]}
     ]
   end
 end

--- a/proca/lib/proca/users.ex
+++ b/proca/lib/proca/users.ex
@@ -9,6 +9,7 @@ defmodule Proca.Users do
   alias Proca.Users.{User, UserToken, UserNotifier}
   import Proca.Validations, only: [peek_unique_error: 1]
 
+  import Logger
   ## Database getters
 
   @doc """
@@ -374,6 +375,16 @@ defmodule Proca.Users do
     end
   end
 
+  def get_user_by_api_token(token) do
+    with {:ok, query} <- UserToken.verify_user_token_query(token, "api"),
+         {%User{} = user, %UserToken{} = user_token} <- Repo.one(query) do
+      Proca.Users.Status.api_token_used(user, user_token)
+      user
+    else
+      _ -> nil
+    end
+  end
+
   @doc """
   Resets the user password.
 
@@ -394,6 +405,23 @@ defmodule Proca.Users do
     |> case do
       {:ok, %{user: user}} -> {:ok, user}
       {:error, :user, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  def reset_api_token(user) do
+    {token, token_record} = UserToken.build_api_token(user)
+
+    Ecto.Multi.new()
+    |> Ecto.Multi.delete_all(:tokens, UserToken.user_and_contexts_query(user, ["api"]))
+    |> Ecto.Multi.insert(:api, token_record)
+    |> Repo.transaction()
+    |> case do
+      {:ok, _} ->
+        {:ok, token}
+
+      {:error, _, errors, _} ->
+        error("Problem reseting API #{errors}")
+        {:error, errors}
     end
   end
 end

--- a/proca/lib/proca/users/status.ex
+++ b/proca/lib/proca/users/status.ex
@@ -1,0 +1,66 @@
+defmodule Proca.Users.Status do
+  use GenServer
+
+  import Ecto.Query
+  import Ecto.Changeset
+  import Proca.Repo, only: [all: 1, update!: 1]
+
+  alias Proca.Users.{User, UserToken}
+
+  @interval 10_000
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    interval = Keyword.get(opts, :interval, @interval)
+
+    call_me(interval)
+
+    {
+      :ok,
+      %{
+        token_last_seen: %{},
+        interval: interval
+      }
+    }
+  end
+
+  defp call_me(ms) do
+    Process.send_after(self(), :sync, ms)
+  end
+
+  @impl true
+  def handle_cast({:api_token_used, token, _user}, st) do
+    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+
+    {
+      :noreply,
+      %{st | token_last_seen: Map.put(st.token_last_seen, token.id, now)}
+    }
+  end
+
+  def api_token_used(%User{} = user, %UserToken{} = token) do
+    GenServer.cast(__MODULE__, {:api_token_used, token, user})
+  end
+
+  @impl true
+  def handle_info(:sync, st) do
+    ids = Map.keys(st.token_last_seen)
+    tokens = all(from ut in UserToken, where: ut.id in ^ids)
+
+    tokens
+    |> Enum.each(fn tok ->
+      update!(change(tok, inserted_at: st.token_last_seen[tok.id]))
+    end)
+
+    call_me(st.interval)
+
+    {
+      :noreply,
+      %{st | token_last_seen: %{}}
+    }
+  end
+end

--- a/proca/lib/proca/users/user_token.ex
+++ b/proca/lib/proca/users/user_token.ex
@@ -10,6 +10,8 @@ defmodule Proca.Users.UserToken do
   @reset_password_validity_in_days 1
   @confirm_validity_in_days 7
   @change_email_validity_in_days 7
+  # after last use, check Proca.Users.Status for token refresh on use
+  @api_validity_in_days 30
   @session_validity_in_days 60
 
   schema "users_tokens" do
@@ -58,8 +60,18 @@ defmodule Proca.Users.UserToken do
     build_hashed_token(user, context, user.email)
   end
 
-  defp build_hashed_token(user, context, sent_to) do
-    token = :crypto.strong_rand_bytes(@rand_size)
+  @doc """
+  Create an API token.
+
+  We hash it so to avoid reconstruction. Valid for 1 year?
+  """
+  def build_api_token(user) do
+    # Prefix will base64 to API-
+    build_hashed_token(user, "api", nil, <<0, 242, 62>>)
+  end
+
+  defp build_hashed_token(user, context, sent_to, prefix \\ "") do
+    token = prefix <> :crypto.strong_rand_bytes(@rand_size)
     hashed_token = :crypto.hash(@hash_algorithm, token)
 
     {Base.url_encode64(token, padding: false),
@@ -97,6 +109,7 @@ defmodule Proca.Users.UserToken do
 
   defp days_for_context("confirm"), do: @confirm_validity_in_days
   defp days_for_context("reset_password"), do: @reset_password_validity_in_days
+  defp days_for_context("api"), do: @api_validity_in_days
 
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
@@ -111,6 +124,29 @@ defmodule Proca.Users.UserToken do
         query =
           from token in token_and_context_query(hashed_token, context),
             where: token.inserted_at > ago(@change_email_validity_in_days, "day")
+
+        {:ok, query}
+
+      :error ->
+        :error
+    end
+  end
+
+  @doc """
+  Query returns {user, user_token} !
+  """
+  def verify_user_token_query(token, context) do
+    case Base.url_decode64(token, padding: false) do
+      {:ok, decoded_token} ->
+        hashed_token = :crypto.hash(@hash_algorithm, decoded_token)
+
+        days = days_for_context(context)
+
+        query =
+          from token in token_and_context_query(hashed_token, context),
+            join: user in assoc(token, :user),
+            where: token.inserted_at > ago(^days, "day"),
+            select: {user, token}
 
         {:ok, query}
 
@@ -135,5 +171,9 @@ defmodule Proca.Users.UserToken do
 
   def user_and_contexts_query(user, [_ | _] = contexts) do
     from t in Proca.Users.UserToken, where: t.user_id == ^user.id and t.context in ^contexts
+  end
+
+  def expires_at(%Proca.Users.UserToken{inserted_at: i, context: c}) do
+    NaiveDateTime.add(i, days_for_context(c) * 24 * 60 * 60, :second)
   end
 end

--- a/proca/lib/proca_web/plugs/jwt_auth_plug.ex
+++ b/proca/lib/proca_web/plugs/jwt_auth_plug.ex
@@ -169,9 +169,10 @@ defmodule ProcaWeb.Plugs.JwtAuthPlug do
     UserAuth.assign_current_user(conn, user)
   end
 
+  # heuristic that jwt token must start with ey - base64 for {"
   defp get_token(conn, nil) do
     case Conn.get_req_header(conn, "authorization") do
-      ["Bearer " <> token] -> token
+      ["Bearer ey" <> token] -> "ey" <> token
       _ -> nil
     end
   end

--- a/proca/lib/proca_web/plugs/token_auth_plug.ex
+++ b/proca/lib/proca_web/plugs/token_auth_plug.ex
@@ -1,0 +1,77 @@
+defmodule ProcaWeb.Plugs.TokenAuthPlug do
+  @moduledoc """
+  A plug that reads JWT from Authorization header and authenticates the user.
+
+  options:
+  - query_param - specify if you want to fetch JWT from a query param
+  - enable_session - set user also in phoenix session
+  - email_path - list of keys to get email from in JWT (default ["email"])
+  - email_verified_path = list of keys to get email verified info (default user_metadata.email_verified)
+  - external_id_path - list of keys to get external_id from JWT (default ["sub"])
+  """
+  @behaviour Plug
+
+  alias Plug.Conn
+  alias Proca.Auth
+  alias ProcaWeb.UserAuth
+  alias Proca.Users
+  alias Proca.Users.User
+  import ProcaWeb.Plugs.Helper
+  import Logger
+
+  def init(opts) do
+    opts
+  end
+
+  def call(conn, opts) do
+    conn
+    |> token_auth(opts)
+    |> add_to_context()
+    |> add_to_session(opts[:enable_session])
+  end
+
+  @doc """
+  Return the current user context based on the authorization header
+  """
+  def token_auth(conn, _opts) do
+    with token when not is_nil(token) <- get_token(conn),
+         {:user, %User{} = user} <- {:user, Users.get_user_by_api_token(token)} do
+      UserAuth.assign_current_user(conn, user)
+    else
+      {:user, nil} -> error_halt(conn, 401, "unauthorized", "Cannot verify token")
+      nil -> conn
+    end
+  end
+
+  defp get_token(conn) do
+    case Conn.get_req_header(conn, "authorization") do
+      ["Bearer API-" <> token] -> "API-" <> token
+      _ -> nil
+    end
+  end
+
+  defp add_to_context(conn) do
+    case conn.assigns[:user] do
+      %User{} = u ->
+        Absinthe.Plug.assign_context(conn, %{
+          # XXX for backward compatibility
+          user: u,
+          auth: %Auth{user: u}
+        })
+
+      nil ->
+        conn
+    end
+  end
+
+  defp add_to_session(conn, nil), do: conn
+
+  defp add_to_session(conn, false), do: conn
+
+  defp add_to_session(conn, true) do
+    case conn.assigns[:user] do
+      user = %User{} -> UserAuth.log_in_user(conn, user)
+      nil -> conn
+    end
+  end
+end

--- a/proca/lib/proca_web/resolvers/user.ex
+++ b/proca/lib/proca_web/resolvers/user.ex
@@ -182,4 +182,19 @@ defmodule ProcaWeb.Resolvers.User do
 
     {:ok, User.all(criteria)}
   end
+
+  def api_token(user, _, %{context: %{auth: %Auth{user: user}}}) do
+    case Proca.Repo.one(Proca.Users.UserToken.user_and_contexts_query(user, ["api"])) do
+      nil ->
+        {:ok, nil}
+
+      token ->
+        {:ok,
+         %{
+           expires_at: Proca.Users.UserToken.expires_at(token)
+         }}
+    end
+  end
+
+  def api_token(_, _, _), do: {:ok, nil}
 end

--- a/proca/lib/proca_web/router.ex
+++ b/proca/lib/proca_web/router.ex
@@ -29,6 +29,7 @@ defmodule ProcaWeb.Router do
     plug CORSPlug
     plug ProcaWeb.Plugs.HeadersPlug, ["referer"]
     plug ProcaWeb.Plugs.BasicAuthPlug
+    plug ProcaWeb.Plugs.TokenAuthPlug
     plug ProcaWeb.Plugs.JwtAuthPlug
   end
 

--- a/proca/lib/proca_web/schema/user_types.ex
+++ b/proca/lib/proca_web/schema/user_types.ex
@@ -26,6 +26,10 @@ defmodule ProcaWeb.Schema.UserTypes do
     field :picture_url, :string
     field :job_title, :string
 
+    field :api_token, :api_token do
+      resolve(&Resolvers.User.api_token/3)
+    end
+
     field :is_admin, non_null(:boolean) do
       resolve(fn u, _, _ -> {:ok, can?(u, :instance_owner)} end)
     end
@@ -112,6 +116,14 @@ defmodule ProcaWeb.Schema.UserTypes do
       allow(:user)
       resolve(&Resolvers.User.update_user/3)
     end
+
+    field :reset_api_token, type: non_null(:string) do
+      allow(:user)
+
+      resolve(fn _, _, %{context: %{auth: %{user: user}}} ->
+        Proca.Users.reset_api_token(user)
+      end)
+    end
   end
 
   input_object :org_user_input do
@@ -146,5 +158,10 @@ defmodule ProcaWeb.Schema.UserTypes do
 
     @desc "Exact org name"
     field :org_name, :string
+  end
+
+  @desc "Api token metadata"
+  object :api_token do
+    field :expires_at, non_null(:naive_datetime)
   end
 end


### PR DESCRIPTION
Adds API token feature.

Usage:
1. create token:
```
mutation CreateToken { resetApiToken }
```
returns new api token eg `API-XXXXXXXXXXXX`, valid 365 days.

2. use the token:
put into authorization header: `Authorization: Bearer API-XXXXXXXXXXXXXXX` to authenticate calls.

