### PR TITLE
Nack without shutting down the channel

### DIFF
--- a/sdk/queue/README.MD
+++ b/sdk/queue/README.MD
@@ -11,7 +11,9 @@ This module provides few helpers to work with queues.
 ## Functions
 
 - `syncQueue(url, queueName, callback, options)` - Start reading actions and events from `queueName` queue from AMQP server at `url`. For each action or event, `callback` is called.
+
   - options is a map with:
+
     - `prefetch` - if set, set number of messages to prefetch from queue
     - `keyStore` - decryption key store (see `@proca/crypto` module) if PII of supporters is to be decrypted
 
@@ -24,3 +26,7 @@ This module provides few helpers to work with queues.
 ## AMQP authentication
 
 Use HTTP Basic Auth inlined in url to authenticate to AMQP server (eg. `amqps://username:password@example.com:1572`).
+
+## Version 4.0.0
+
+Function syncQueue is updated to manage the case when it needs to nack a message without closing the channel. It will fail if the callback does not return the boolean. All the apps that use version 3 of this function should be adapted before updating, or they will break.

--- a/sdk/queue/package.json
+++ b/sdk/queue/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "4.0.0",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/sdk/queue/src/queue.ts
+++ b/sdk/queue/src/queue.ts
@@ -103,7 +103,8 @@ export async function syncQueue(
             }
           } else {
             await ch.nack(msg, false, false)
-            console.error("Requeued due to error! Action Id:", action.actionId)
+            console.error("Requeued due to error! Action Id:", action.actionId);
+            return finalizeShutdown();
           }
         })
         .catch(async (e : Error) => {

--- a/sdk/queue/src/queue.ts
+++ b/sdk/queue/src/queue.ts
@@ -84,15 +84,15 @@ export async function syncQueue(
 
       status.running += 1
       return syncer(action, msg, ch)
-        .then(async (proccessed: boolean) => {
-          if (typeof proccessed !== 'boolean') {
+        .then(async (processed: boolean) => {
+          if (typeof processed !== 'boolean') {
             await ch.nack(msg, false, false)
 
             await startShutdown();
             await finalizeShutdown();
             console.error(`Returned value must be boolean. Nack action, actionId: ${action.actionId}):`)
           }
-          if (proccessed) {
+          if (processed) {
             try {
               ch.ack(msg)
               status.running -= 1

--- a/sdk/queue/src/queue.ts
+++ b/sdk/queue/src/queue.ts
@@ -84,8 +84,15 @@ export async function syncQueue(
 
       status.running += 1
       return syncer(action, msg, ch)
-        .then(async (_v: any) => {
-          if (_v) {
+        .then(async (proccessed: boolean) => {
+          if (typeof proccessed !== 'boolean') {
+            await ch.nack(msg, false, false)
+
+            await startShutdown();
+            await finalizeShutdown();
+            console.error(`Returned value must be boolean. Nack action, actionId: ${action.actionId}):`)
+          }
+          if (proccessed) {
             try {
               ch.ack(msg)
               status.running -= 1


### PR DESCRIPTION
Version 4.0.0 @proca/queue

Function syncQueue is updated to manage the case when it needs to nack a message without closing the channel. It will fail if the callback does not return the boolean. All the apps that use version 3 of this function should be adapted before updating, or they will break.