### PR TITLE
Add more context to email templates errors

### DIFF
--- a/proca/lib/proca/service/email_template_directory.ex
+++ b/proca/lib/proca/service/email_template_directory.ex
@@ -143,6 +143,8 @@ defmodule Proca.Service.EmailTemplateDirectory do
 
     with [] <- lookup,
          record when record != nil <- EmailTemplate.one(org: org, name: name, locale: locale) do
+      Sentry.Context.set_extra_context(%{org_id: org.id})
+
       record = EmailTemplate.compile(record)
       cache_template(record, true)
       record


### PR DESCRIPTION
It will add additional information in case of error when trying to compile broken template.

Ref #234 