### PR TITLE
Add reply_enabled to Org

### DIFF
--- a/proca/lib/proca/org.ex
+++ b/proca/lib/proca/org.ex
@@ -104,6 +104,7 @@ defmodule Proca.Org do
       :config,
       :high_security,
       :doi_thank_you,
+      :reply_enabled,
       :custom_supporter_confirm,
       :custom_action_confirm,
       :custom_action_deliver,

--- a/proca/lib/proca/org.ex
+++ b/proca/lib/proca/org.ex
@@ -46,6 +46,7 @@ defmodule Proca.Org do
     belongs_to :email_backend, Proca.Service
     belongs_to :storage_backend, Proca.Service
     field :email_from, :string
+    field :reply_enabled, :boolean, default: true
 
     # supporter confirm in configuration
     field :supporter_confirm, :boolean, default: false

--- a/proca/lib/proca/org.ex
+++ b/proca/lib/proca/org.ex
@@ -17,10 +17,7 @@ defmodule Proca.Org do
   use Proca.Schema, module: __MODULE__
   import Ecto.Changeset
   import Ecto.Query, except: [update: 2]
-  alias Ecto.Multi
   alias Proca.{Org, Service}
-  alias Proca.Service.EmailTemplateDirectory
-  import Logger
 
   schema "orgs" do
     field :name, :string
@@ -248,7 +245,6 @@ defmodule Proca.Org do
   def list(preloads \\ []) do
     all(preload: preloads)
   end
-
 
   @spec active_public_keys([Proca.PublicKey]) :: [Proca.PublicKey]
   def active_public_keys(public_keys) do

--- a/proca/lib/proca/service/email_backend.ex
+++ b/proca/lib/proca/service/email_backend.ex
@@ -186,11 +186,13 @@ defmodule Proca.Service.EmailBackend do
       from_email == org.email_from ->
         email
         |> Email.from({from_name, "#{via_username}+#{domain}@#{via_domain}"})
+        |> maybe_add_reply(from_email, org.reply_enabled)
 
       # Any from email - we will use the username here
       true ->
         email
         |> Email.from({from_name, "#{via_username}+#{username}@#{via_domain}"})
+        |> maybe_add_reply(from_email, org.reply_enabled)
     end
   end
 
@@ -210,4 +212,7 @@ defmodule Proca.Service.EmailBackend do
   def format_custom_id(type, id)
       when type in [:user] and is_bitstring(id),
       do: "#{type}:#{id}"
+
+  defp maybe_add_reply(email, from_email, true), do: Email.header(email, "Reply-To", from_email)
+  defp maybe_add_reply(email, _, _), do: email
 end

--- a/proca/lib/proca/service/email_backend.ex
+++ b/proca/lib/proca/service/email_backend.ex
@@ -45,7 +45,7 @@ defmodule Proca.Service.EmailBackend do
   """
 
   alias Proca.{Org, Service}
-  alias Proca.Service.{EmailTemplate, EmailMerge}
+  alias Proca.Service.EmailTemplate
   alias Swoosh.Email
   import Proca.Stage.Support, only: [flatten_keys: 2]
 
@@ -80,7 +80,7 @@ defmodule Proca.Service.EmailBackend do
     |> apply(:supports_templates?, [org])
   end
 
-  def supports_templates?(org = %Org{email_backend: nil}), do: false
+  def supports_templates?(_org = %Org{email_backend: nil}), do: false
 
   def list_templates(org = %Org{email_backend: %Service{name: name}}) do
     service_module(name)
@@ -95,7 +95,7 @@ defmodule Proca.Service.EmailBackend do
 
   Surprise: you can get  `{:error, [:ok, :ok, :ok]}` with there was some error but adapter decided to drop the email (fatal problem, retry will not help)
   """
-  @spec deliver([%Email{}], %Org{}, %EmailTemplate{} | nil) ::
+  @spec deliver([Email.t()], Org.t(), EmailTemplate.t() | nil) ::
           :ok | {:error, [:ok | {:error, String.t()}]}
   def deliver(recipients, org = %Org{email_backend: %Service{name: name}}, email_template \\ nil) do
     backend = service_module(name)
@@ -142,7 +142,7 @@ defmodule Proca.Service.EmailBackend do
   end
 
   # template renderers of Mailjet and friends are happier with a flat list of vars
-  defp prepare_fields(%Email{assigns: a} = email) do
+  defp prepare_fields(email = %Email{assigns: a}) do
     %{email | assigns: flatten_keys(a, "")}
   end
 

--- a/proca/lib/proca_web/resolvers/org.ex
+++ b/proca/lib/proca_web/resolvers/org.ex
@@ -61,7 +61,8 @@ defmodule ProcaWeb.Resolvers.Org do
         :supporter_confirm,
         :supporter_confirm_template,
         :high_security,
-        :doi_thank_you
+        :doi_thank_you,
+        :reply_enabled
       ])
     }
   end

--- a/proca/lib/proca_web/schema/org_types.ex
+++ b/proca/lib/proca_web/schema/org_types.ex
@@ -177,6 +177,9 @@ defmodule ProcaWeb.Schema.OrgTypes do
     @desc "Only send thank you emails to opt-ins"
     field :doi_thank_you, :boolean
 
+    @desc "Enable reply_to for emails"
+    field :reply_enabled, :boolean
+
     @desc "Config"
     field :config, :json
   end
@@ -347,6 +350,9 @@ defmodule ProcaWeb.Schema.OrgTypes do
 
     @desc "Only send thank you emails to opt-ins"
     field :doi_thank_you, non_null(:boolean)
+
+    @desc "Enable reply_to for emails"
+    field :reply_enabled, :boolean
   end
 
   @desc "Encryption or sign key with integer id (database)"

--- a/proca/mix.exs
+++ b/proca/mix.exs
@@ -4,7 +4,7 @@ defmodule Proca.MixProject do
   def project do
     [
       app: :proca,
-      version: "3.4.7",
+      version: "3.5.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/proca/mix.exs
+++ b/proca/mix.exs
@@ -4,7 +4,7 @@ defmodule Proca.MixProject do
   def project do
     [
       app: :proca,
-      version: "3.4.6",
+      version: "3.4.7",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/proca/priv/repo/migrations/20240606100400_add_org_reply_enabled.exs
+++ b/proca/priv/repo/migrations/20240606100400_add_org_reply_enabled.exs
@@ -1,0 +1,9 @@
+defmodule Proca.Repo.Migrations.AddOrgReplyEnabled do
+  use Ecto.Migration
+
+  def change do
+    alter table(:orgs) do
+      add :reply_enabled, :boolean, default: true
+    end
+  end
+end

--- a/proca/test/server/mtt_worker_test.exs
+++ b/proca/test/server/mtt_worker_test.exs
@@ -184,6 +184,9 @@ defmodule Proca.Server.MTTWorkerTest do
       mbox = Proca.TestEmailBackend.mailbox(email)
 
       assert length(mbox) == 20
+
+      msg = List.first(mbox)
+      assert %{"Reply-To" => _} = msg.headers
     end
   end
 


### PR DESCRIPTION
It will allow us to configure if reply_to should be enabled for specific org or not.

Fix #247 