### PR TITLE
Put limits on MTT

### DIFF
--- a/proca/config/dev.exs
+++ b/proca/config/dev.exs
@@ -36,8 +36,6 @@ case System.get_env("ORGANISATION") do
     config :proca, Proca, org_name: org_name
 end
 
-config :proca, Proca.Server.MTTWorker, max_messages: 2
-
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #

--- a/proca/config/dev.exs
+++ b/proca/config/dev.exs
@@ -36,6 +36,8 @@ case System.get_env("ORGANISATION") do
     config :proca, Proca, org_name: org_name
 end
 
+config :proca, Proca.Server.MTTWorker, max_messages: 2
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #

--- a/proca/config/releases.exs
+++ b/proca/config/releases.exs
@@ -118,6 +118,9 @@ config :proca, Proca,
 
 config :proca, Proca.Supporter, fpr_seed: System.get_env("FINGERPRINT_SEED", "")
 
+config :proca, Proca.Server.MTTWorker,
+  max_messages_per_cycle: String.to_integer(System.get_env("MAX_MESSAGES_PER_CYCLE", "99"))
+
 # Configures Elixir's Logger
 config :logger,
   backends: [:console, {LoggerFileBackend, :error_log}, {LoggerFileBackend, :audit_log}],

--- a/proca/config/test.exs
+++ b/proca/config/test.exs
@@ -25,3 +25,5 @@ config :logger, level: :warn
 config :proca, Proca,
   org_name: "instance",
   start_daemon_servers: false
+
+config :proca, Proca.Server.MTTWorker, max_messages_per_cycle: 99

--- a/proca/config/test.exs
+++ b/proca/config/test.exs
@@ -11,8 +11,6 @@ config :proca, Proca.Repo,
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :proca, Proca.Server.MTTWorker, max_messages: 6
-
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :proca, ProcaWeb.Endpoint,

--- a/proca/config/test.exs
+++ b/proca/config/test.exs
@@ -11,6 +11,8 @@ config :proca, Proca.Repo,
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
 
+config :proca, Proca.Server.MTTWorker, max_messages: 6
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :proca, ProcaWeb.Endpoint,

--- a/proca/lib/proca/action/message.ex
+++ b/proca/lib/proca/action/message.ex
@@ -80,7 +80,7 @@ defmodule Proca.Action.Message do
   Returns a query for [message, target, action] for specified target id list, or :all for all.
   Use sent and testing flags to further select (not) sent or (not) testing actions
   """
-  @spec select_by_targets([number] | :all, boolean, boolean) :: %Ecto.Query{}
+  @spec select_by_targets([number] | :all, boolean | [boolean], boolean) :: Ecto.Query.t()
   def select_by_targets(target_ids, sent \\ false, testing \\ false) do
     import Ecto.Query
 

--- a/proca/lib/proca/server/mtt_worker.ex
+++ b/proca/lib/proca/server/mtt_worker.ex
@@ -179,7 +179,6 @@ defmodule Proca.Server.MTTWorker do
       Message.select_by_targets(target_ids, [false, true])
       |> select([m, t, a], %{
         target_id: t.id,
-        # goal: count(m.id) * ^cycle / ^all_cycles,
         goal:
           fragment("LEAST(?, ?)", count(m.id) * ^cycle / ^all_cycles, ^max_messages_per_cycle()),
         sent: fragment("count(?) FILTER (WHERE sent)", m.id)

--- a/proca/lib/proca/server/mtt_worker.ex
+++ b/proca/lib/proca/server/mtt_worker.ex
@@ -372,6 +372,12 @@ defmodule Proca.Server.MTTWorker do
   end
 
   defp max_messages_per_cycle() do
-    Application.get_env(:proca, __MODULE__, max_messages_per_cycle: 100)[:max_messages_per_cycle]
+    max_messages = Application.get_env(:proca, __MODULE__)[:max_messages_per_cycle]
+
+    cond do
+      is_nil(max_messages) -> 99
+      max_messages < 1 -> 1
+      true -> max_messages
+    end
   end
 end

--- a/proca/lib/proca/server/mtt_worker.ex
+++ b/proca/lib/proca/server/mtt_worker.ex
@@ -373,10 +373,10 @@ defmodule Proca.Server.MTTWorker do
   defp max_messages_per_cycle() do
     max_messages = Application.get_env(:proca, __MODULE__)[:max_messages_per_cycle]
 
-    cond do
-      is_nil(max_messages) -> 99
-      max_messages < 1 -> 1
-      true -> max_messages
+    if max_messages < 1 do
+      1
+    else
+      max_messages
     end
   end
 end

--- a/proca/lib/proca/server/mtt_worker.ex
+++ b/proca/lib/proca/server/mtt_worker.ex
@@ -179,7 +179,9 @@ defmodule Proca.Server.MTTWorker do
       Message.select_by_targets(target_ids, [false, true])
       |> select([m, t, a], %{
         target_id: t.id,
-        goal: count(m.id) * ^cycle / ^all_cycles,
+        # goal: count(m.id) * ^cycle / ^all_cycles,
+        goal:
+          fragment("LEAST(?, ?)", count(m.id) * ^cycle / ^all_cycles, ^max_messages_per_cycle()),
         sent: fragment("count(?) FILTER (WHERE sent)", m.id)
       })
       |> group_by([m, t, a], t.id)
@@ -367,5 +369,9 @@ defmodule Proca.Server.MTTWorker do
     email
     |> Email.assign(:body, html_body)
     |> Email.assign(:subject, subject)
+  end
+
+  defp max_messages_per_cycle() do
+    Application.get_env(:proca, __MODULE__, max_messages_per_cycle: 100)[:max_messages_per_cycle]
   end
 end

--- a/proca/mix.exs
+++ b/proca/mix.exs
@@ -4,7 +4,7 @@ defmodule Proca.MixProject do
   def project do
     [
       app: :proca,
-      version: "3.5.0",
+      version: "3.6.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
This will prevent MTTWorker from sending more than MAX_MESSAGES_PER_CYCLE in one cycle.

Ref #232