### PR TITLE
Wrap single mailjet webhook event

### DIFF
--- a/proca/lib/proca_web/controllers/webhook_controller.ex
+++ b/proca/lib/proca_web/controllers/webhook_controller.ex
@@ -27,4 +27,9 @@ defmodule ProcaWeb.WebhookController do
     conn
     |> send_resp(:ok, "")
   end
+
+  def mailjet(conn, event) do
+    # If we receive a single event instead of list we should wrap it
+    mailjet(conn, %{"_json" => [event]})
+  end
 end


### PR DESCRIPTION
If we don't check "Group events" in mailjet webhook configuration, mailjet would send a json object to out webhook endpoint.

Fix #266 