### PR TITLE
Change the email rewriting to use SRS, fixes #272

### DIFF
--- a/proca/config/config.exs
+++ b/proca/config/config.exs
@@ -55,6 +55,11 @@ config :proca, Proca,
   start_daemon_servers: true,
   mtt_cycle_time: 3
 
+config :proca, Proca.Service.EmailBackend,
+  srs_key: System.get_env("EMAIL_SRS_KEY") || "teiy1sah8seengiem0ee2Yai",
+  srs_prefix: System.get_env("EMAIL_SRS_PREFIX") || "SRS0"
+
+
 # FPR seed only for development
 config :proca, Proca.Supporter, fpr_seed: "4xFc6MsafPEwc6ME"
 


### PR DESCRIPTION
Currently matches https://github.com/samcday/srs.js (just to have some reference)

But turns out it's a pretty fuzzy "standard", haha. Some implementations [lowercase](https://github.com/mileusna/srs/blob/501e7d108e91b985514e3b889f6fd2413125bfe9/srs.go#L76) the hmac input; some have [replaced sha1 with sha256](https://github.com/xyfir/sender-rewriting-scheme/blob/5c4cad80ab76e2af3ad604757deb44b00df23396/src/srs.ts#L60) etc.