### PR TITLE
Optimize campaigns by org query

### DIFF
--- a/lib/proca/campaign.ex
+++ b/lib/proca/campaign.ex
@@ -22,7 +22,7 @@ defmodule Proca.Campaign do
     field :status, CampaignStatus, default: :live
     field :supporter_confirm, :boolean, default: false
     field :supporter_confirm_template, :string
-    field :start, :date,  source: :start_date
+    field :start, :date, source: :start_date
     field :end, :date, source: :end_date
 
     belongs_to :org, Proca.Org
@@ -154,7 +154,8 @@ defmodule Proca.Campaign do
       on: c.id == ap.campaign_id,
       where: ap.org_id == ^org.id or c.org_id == ^org.id
     )
-    |> distinct(true)
+    |> distinct([c], c.id)
+    |> order_by([c], c.id)
   end
 
   def get_with_local_pages(campaign_id) when is_integer(campaign_id) do


### PR DESCRIPTION
### Problem
`campaign.select_by_org/1` was taking over 1,000ms to execute with moderate data, because we used a "global unique" check `distinct(true)`. Postgres was comparing every column (including large strings or JSONs across all joined rows to find duplicates. This is wasteful because we only care about uniqueness by ID.
The sort key in the original plan:
Sort Key: c.id, c.name, c.title, c.org_id, c.inserted_at, c.updated_at,
          c.force_delivery, c.external_id, c.public_actions, c.config,
          c.contact_schema, c.transient_actions, c.status, c.supporter_confirm,
          c.supporter_confirm_template, c.start_date, c.end_date

To analyze the old query with actual data:
```bash
EXPLAIN (ANALYZE, BUFFERS)
SELECT DISTINCT c.*
FROM campaigns c
LEFT JOIN action_pages ap ON c.id = ap.campaign_id
WHERE ap.org_id = 264 OR c.org_id = 264;
```

### Fix
I have updated the query to use distinct: [asc: c.id]. Instead of comparing every field in the table, it deduplicates rows by ID only.

To analyze a new query:
```bash
EXPLAIN (ANALYZE, BUFFERS)
SELECT DISTINCT ON (c.id) c.*
FROM campaigns c
LEFT JOIN action_pages ap ON c.id = ap.campaign_id
WHERE ap.org_id = 264 OR c.org_id = 264
ORDER BY c.id;
```

### Performance 

  | Before | After
-- | -- | --
Execution time | 1393ms | 2.6ms
Buffers hit | 22,545 | 159
Sort key | 17 columns | c.id only

### Concern
- I can figure out the way to test this (other than in production :| ).
- There might be a better way to optimize this query (by using `EXISTS` instead of `JOIN` + `DISTINCT`), but this solution should be simple and sufficient for our data load.
