### PR TITLE
fix brevo and contact retention

### DIFF
--- a/lib/proca/org.ex
+++ b/lib/proca/org.ex
@@ -110,7 +110,7 @@ defmodule Proca.Org do
     ])
     |> cast_backend(
       :email_backend,
-      [:mailjet, :ses, :smtp, :system, :testmail, :preview],
+      [:mailjet, :ses, :smtp, :system, :testmail, :preview, :brevo],
       attrs,
       org
     )

--- a/lib/proca/supporter/retention_cleanup.ex
+++ b/lib/proca/supporter/retention_cleanup.ex
@@ -134,7 +134,7 @@ defmodule Proca.Supporter.RetentionCleanup do
       )
 
     if campaign_id do
-      where(base, [_s, _c, a], a.campaign_id == ^campaign_id)
+      where(base, [_s, _c, a], a.campaign_id != ^campaign_id)
     else
       base
     end


### PR DESCRIPTION
- Added brevo to list of supported backend
- filter to actions in other campaigns instead, so a fingerprint is only protected if the supporter is still active elsewhere. If their only activity is in a closed campaign being cleaned up, they're eligible for deletion.