### PR TITLE
handle repeat actions

### DIFF
--- a/guides/Processing.md
+++ b/guides/Processing.md
@@ -44,6 +44,20 @@ The other special link to _reject_ a supporter can be used to mark a _confirming
 
 Proca also supports confirming of each action separately (_action confirmation_), this was not used much in real world. However, in this case we don't care if the supporter email is real, we care more about the action content, for example, custom fields, MTT body, attached file. We would put actions in a wait/confirming state until such actions are moderated/checked and accepted. **Partly unimplemented**: There is no api or link format to confirm or reject a particular action (could be easily added but needs a proper use-case).
 
+## Duplicate actions
+
+When the same supporter (matched by contact data fingerprint) submits more than one action on the same action page (same campaign, same page), the second and subsequent actions are marked as duplicates. The supporter's `dupe_rank` is set to a value > 0, and the action's `processing_status` is set to `:repeat` (value 5).
+
+Cross-page duplicates (same supporter, different page in the same campaign) are NOT marked as `:repeat` — they reach `:delivered` status with `dupe_rank > 0` in the contact payload.
+
+Duplicate (`:repeat`) actions are:
+
+- **Delivered to the queue**: On first processing, a `:repeat` action is still emitted to the `cus.X.deliver` exchange with `dupeRank > 0` in the contact payload. Consumers can use `dupeRank` to decide how to handle them (e.g. skip CRM sync but send a different email).
+- **Exported**: `exportActions` / `actions` / `contacts` queries include `:repeat` actions. The `contact.dupeRank` field in the export response will be > 0 for these.
+- **Requeue-able**: The `requeueActions` mutation treats `:repeat` actions the same as `:delivered` — they can be sent to any delivery destination.
+
+A bouncing email or rejection will mark a supporter as `:rejected`, which in turn rejects all their associated actions regardless of dupe status.
+
 ## Delivery
 
 Delivery of actions means that action is ready to be served and consumed. Actions can be delivered using internal and external mechanisms.

--- a/lib/proca/stage/support.ex
+++ b/lib/proca/stage/support.ex
@@ -33,6 +33,8 @@ defmodule Proca.Stage.Support do
     :action_confirm
   end
 
+  def action_stage(%Action{processing_status: :repeat, supporter: %Supporter{}}), do: :deliver
+
   def action_stage(%Action{supporter: %Supporter{}}), do: nil
 
   def bulk_actions_data(action_ids, stage \\ :deliver, org_id \\ nil) do

--- a/lib/proca_web/resolvers/export_actions.ex
+++ b/lib/proca_web/resolvers/export_actions.ex
@@ -74,7 +74,7 @@ defmodule ProcaWeb.Resolvers.ExportActions do
         q,
         [a, s],
         s.processing_status == :accepted and
-          a.processing_status in [:accepted, :delivered]
+          a.processing_status in [:accepted, :delivered, :repeat]
       )
     end
   end
@@ -91,7 +91,7 @@ defmodule ProcaWeb.Resolvers.ExportActions do
   def filter_consent(q, _), do: q
 
   def format_contact(
-        %Supporter{fingerprint: ref},
+        %Supporter{fingerprint: ref, dupe_rank: dupe_rank},
         %Contact{
           payload: payload,
           crypto_nonce: nonce,
@@ -101,6 +101,7 @@ defmodule ProcaWeb.Resolvers.ExportActions do
       ) do
     %{
       contact_ref: Supporter.base_encode(ref),
+      dupe_rank: dupe_rank,
       payload: Contact.base_encode(payload),
       nonce: Contact.base_encode(nonce),
       public_key: %{id: pk_id, public: PublicKey.base_encode(pk_key)},
@@ -109,13 +110,14 @@ defmodule ProcaWeb.Resolvers.ExportActions do
   end
 
   def format_contact(
-        %Supporter{fingerprint: ref},
+        %Supporter{fingerprint: ref, dupe_rank: dupe_rank},
         %Contact{
           payload: payload
         }
       ) do
     %{
       contact_ref: Supporter.base_encode(ref),
+      dupe_rank: dupe_rank,
       payload: payload
     }
   end

--- a/lib/proca_web/schema/action_types.ex
+++ b/lib/proca_web/schema/action_types.ex
@@ -307,6 +307,8 @@ defmodule ProcaWeb.Schema.ActionTypes do
   object :contact do
     @desc "Contact ref (fingerprint) of supporter"
     field :contact_ref, non_null(:id)
+    @desc "Rank of this action among actions from the same contact in this campaign (0 = first, >0 = duplicate)"
+    field :dupe_rank, non_null(:integer)
     @desc "Stringified json with PII optionally encrypted"
     field :payload, non_null(:string)
     @desc "Encryption nonce value"


### PR DESCRIPTION
Closes #399

  - Include repeat actions in queries
  - Expose dupe_rank in the exported contact payload and GraphQL
  - Document duplicate action  in Processing.md