### PR TITLE
Handle orgx transactional email backend always the same when false

### DIFF
--- a/lib/proca/org.ex
+++ b/lib/proca/org.ex
@@ -183,9 +183,13 @@ defmodule Proca.Org do
     :disable
   end
 
-  defp cast_backend_service(type, :system, _org)
-       when type in [:email_backend, :transactional_email_backend] do
+  defp cast_backend_service(:email_backend, :system, _org) do
     Proca.Org.one([:instance] ++ [preload: [:email_backend]]).email_backend
+  end
+
+  # Returns nil if instance org has no transactional backend — for_transactional_email/2 will then fall back to orgx.email_backend.
+  defp cast_backend_service(:transactional_email_backend, :system, _org) do
+    Proca.Org.one([:instance] ++ [preload: [:transactional_email_backend]]).transactional_email_backend
   end
 
   defp cast_backend_service(_type, service, org) when is_atom(service) do


### PR DESCRIPTION
### Fixed:
 When set to "system", the transactional email backend now correctly points to the instance org's transactional backend instead of its regular email backend.

#### Fallback
When an org X sets its transactional email backend to "system", it means "use whatever the instance org has configured for transactional emails". If the instance org has no transactional backend set up, we treat it as if transactional is not set at all for org X. Org X will automatically fall back to its own regular email backend (not the system's).