### PR TITLE
Transactional fallback fix

### DIFF
--- a/lib/proca/org.ex
+++ b/lib/proca/org.ex
@@ -174,9 +174,6 @@ defmodule Proca.Org do
         :disable ->
           put_change(chset, String.to_existing_atom("#{backend_type}_id"), nil)
 
-        :ignore ->
-          chset
-
         {:error, message} ->
           add_error(chset, backend_type, message)
       end

--- a/lib/proca/org.ex
+++ b/lib/proca/org.ex
@@ -173,6 +173,12 @@ defmodule Proca.Org do
 
         :disable ->
           put_change(chset, String.to_existing_atom("#{backend_type}_id"), nil)
+
+        :ignore ->
+          chset
+
+        {:error, message} ->
+          add_error(chset, backend_type, message)
       end
     else
       chset
@@ -187,11 +193,12 @@ defmodule Proca.Org do
     Proca.Org.one([:instance] ++ [preload: [:email_backend]]).email_backend
   end
 
-  # Returns nil if instance org has no transactional backend — for_transactional_email/2 will then fall back to orgx.email_backend.
-  # If instance org has no transactional backend, returns :disable (sets to nil) — for_transactional_email/2 will then fall back to orgx.email_backend.
+  # If instance org has no transactional backend configured, fails with an error
   defp cast_backend_service(:transactional_email_backend, :system, _org) do
     instance = Proca.Org.one([:instance] ++ [preload: [:transactional_email_backend]])
-    instance.transactional_email_backend || :disable
+
+    instance.transactional_email_backend ||
+      {:error, "instance org has no transactional email backend configured"}
   end
 
   defp cast_backend_service(_type, service, org) when is_atom(service) do

--- a/lib/proca/org.ex
+++ b/lib/proca/org.ex
@@ -188,8 +188,10 @@ defmodule Proca.Org do
   end
 
   # Returns nil if instance org has no transactional backend — for_transactional_email/2 will then fall back to orgx.email_backend.
+  # If instance org has no transactional backend, returns :disable (sets to nil) — for_transactional_email/2 will then fall back to orgx.email_backend.
   defp cast_backend_service(:transactional_email_backend, :system, _org) do
-    Proca.Org.one([:instance] ++ [preload: [:transactional_email_backend]]).transactional_email_backend
+    instance = Proca.Org.one([:instance] ++ [preload: [:transactional_email_backend]])
+    instance.transactional_email_backend || :disable
   end
 
   defp cast_backend_service(_type, service, org) when is_atom(service) do

--- a/test/org_test.exs
+++ b/test/org_test.exs
@@ -98,24 +98,42 @@ defmodule OrgTest do
   end
 
   describe "changeset transactional_email_backend: :system" do
-    test "resolves to the instance org's own email backend" do
+    test "resolves to the instance org's transactional email backend" do
       instance_org =
         case Org.one([:instance]) do
           nil -> Repo.insert!(%Org{name: Org.instance_org_name(), title: "Instance Org"})
           o -> o
         end
 
-      instance_backend = attached_service(instance_org, :ses)
+      instance_trans_backend = attached_service(instance_org, :ses)
 
       instance_org
-      |> change(email_backend_id: instance_backend.id)
+      |> change(transactional_email_backend_id: instance_trans_backend.id)
       |> Repo.update!()
 
       org = Factory.insert(:org)
 
       ch = Org.changeset(org, %{transactional_email_backend: :system})
       assert ch.valid?
-      assert get_change(ch, :transactional_email_backend_id) == instance_backend.id
+      assert get_change(ch, :transactional_email_backend_id) == instance_trans_backend.id
+    end
+
+    test "resolves to nil if instance org has no transactional email backend" do
+      instance_org =
+        case Org.one([:instance]) do
+          nil -> Repo.insert!(%Org{name: Org.instance_org_name(), title: "Instance Org"})
+          o -> o
+        end
+
+      instance_org
+      |> change(transactional_email_backend_id: nil)
+      |> Repo.update!()
+
+      org = Factory.insert(:org)
+
+      ch = Org.changeset(org, %{transactional_email_backend: :system})
+      assert ch.valid?
+      assert get_change(ch, :transactional_email_backend_id) == nil
     end
   end
 end

--- a/test/org_test.exs
+++ b/test/org_test.exs
@@ -118,7 +118,7 @@ defmodule OrgTest do
       assert get_change(ch, :transactional_email_backend_id) == instance_trans_backend.id
     end
 
-    test "resolves to nil if instance org has no transactional email backend" do
+    test "fails if instance org has no transactional email backend" do
       instance_org =
         case Org.one([:instance]) do
           nil -> Repo.insert!(%Org{name: Org.instance_org_name(), title: "Instance Org"})
@@ -132,8 +132,8 @@ defmodule OrgTest do
       org = Factory.insert(:org)
 
       ch = Org.changeset(org, %{transactional_email_backend: :system})
-      assert ch.valid?
-      assert get_change(ch, :transactional_email_backend_id) == nil
+      refute ch.valid?
+      assert {"instance org has no transactional email backend configured", _} = ch.errors[:transactional_email_backend]
     end
   end
 end


### PR DESCRIPTION
When an org sets transactional_email_backend to system, and the instance org has no transactional backend configured, the mutation fails with a clear error instead of silently setting the field to null.