### PR TITLE
fix(smtp): add required SSL verify/cacertfile option and support smtp…

### DIFF
--- a/lib/proca/service/smtp.ex
+++ b/lib/proca/service/smtp.ex
@@ -27,26 +27,25 @@ defmodule Proca.Service.SMTP do
       |> Enum.map(&SMTP.deliver(&1, conf))
 
     Enum.each(results, fn
-      {:ok, _} ->
-        :ok
-
       {:error, reason} ->
         Sentry.capture_message("Failed to send email by SMTP: #{inspect(reason)}",
           extra: %{org: org_name},
           result: :none
         )
+
+      {:ok, _} ->
+        :ok
     end)
 
-    :ok
-    # XXX not clear which errors are retryable?
-    # if Enum.all?(results, & &1 == :ok) do
-    #   :ok
-    # else
-    #   {:error, Enum.map(results, fn
-    #       {:ok, _r} -> :ok
-    #       {:error, reason} -> {:error, inspect(reason)}
-    #     end)}
-    # end
+    if Enum.all?(results, &match?({:ok, _}, &1)) do
+      :ok
+    else
+      {:error,
+       Enum.map(results, fn
+         {:ok, _r} -> :ok
+         {:error, reason} -> {:error, inspect(reason)}
+       end)}
+    end
   end
 
   def deliver(email, org) do
@@ -74,8 +73,8 @@ defmodule Proca.Service.SMTP do
 
   def put_security(opts, "ssl") do
     [{:ssl, true} | opts]
-    |> Keyword.update(:port, 587, fn
-      nil -> 587
+    |> Keyword.update(:port, 465, fn
+      nil -> 465
       x -> x
     end)
     |> Keyword.put(:sockopts, [

--- a/lib/proca/service/smtp.ex
+++ b/lib/proca/service/smtp.ex
@@ -4,6 +4,8 @@ defmodule Proca.Service.SMTP do
   alias Swoosh.Email
   alias Swoosh.Adapters.SMTP
 
+  @cacerts :public_key.cacerts_get()
+
   @impl true
   def supports_templates?(_org) do
     false
@@ -78,7 +80,7 @@ defmodule Proca.Service.SMTP do
     end)
     |> Keyword.put(:sockopts, [
       verify: :verify_peer,
-      cacerts: :public_key.cacerts_get()
+      cacerts: @cacerts
     ])
   end
 
@@ -90,7 +92,7 @@ defmodule Proca.Service.SMTP do
     end)
     |> Keyword.put(:sockopts, [
       verify: :verify_peer,
-      cacerts: :public_key.cacerts_get()
+      cacerts: @cacerts
     ])
   end
 
@@ -102,7 +104,7 @@ defmodule Proca.Service.SMTP do
     end)
     |> Keyword.put(:tls_options, [
       verify: :verify_peer,
-      cacerts: :public_key.cacerts_get()
+      cacerts: @cacerts
     ])
   end
 

--- a/lib/proca/service/smtp.ex
+++ b/lib/proca/service/smtp.ex
@@ -76,8 +76,22 @@ defmodule Proca.Service.SMTP do
       nil -> 587
       x -> x
     end)
+    |> Keyword.put(:sockopts, [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get()
+    ])
+  end
 
-    # set if not set
+  def put_security(opts, "smtps") do
+    [{:ssl, true} | opts]
+    |> Keyword.update(:port, 465, fn
+      nil -> 465
+      x -> x
+    end)
+    |> Keyword.put(:sockopts, [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get()
+    ])
   end
 
   def put_security(opts, "tls") do
@@ -86,8 +100,10 @@ defmodule Proca.Service.SMTP do
       nil -> 25
       x -> x
     end)
-
-    # set if not set
+    |> Keyword.put(:tls_options, [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get()
+    ])
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -82,7 +82,6 @@ defmodule Proca.MixProject do
       {:supabase, "~> 0.2.3"},
       {:tesla, "~> 1.4.1"},
       {:mint, "~> 1.0"},
-      {:castore, "~> 0.1"},
       {:hcaptcha, "~> 0.0.1"},
       {:sweet_xml, "~> 0.6"},
       {:joken, "~> 2.4"},

--- a/test/service/smtp_test.exs
+++ b/test/service/smtp_test.exs
@@ -9,6 +9,10 @@ defmodule Proca.Service.SMTPTest do
 
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 25
+    assert c[:tls] == :always
+    assert %{tls_options: [verify: :verify_peer, cacerts: cacerts]} = c
+    assert is_list(cacerts)
+    assert length(cacerts) > 0
 
     c = Proca.Service.SMTP.config(%{@tls_service | host: @tls_service.host <> ":1234"})
 
@@ -18,5 +22,31 @@ defmodule Proca.Service.SMTPTest do
 
     assert c[:relay] == "secure.org"
     assert c[:port] == 587
+    assert c[:ssl] == true
+    assert %{sockopts: [verify: :verify_peer, cacerts: cacerts2]} = c
+    assert is_list(cacerts2)
+    assert length(cacerts2) > 0
+  end
+
+  test "smtps config" do
+    s = %Service{user: "joe", password: "qwerty", host: "smtps://smtp.mail.op"}
+    c = Proca.Service.SMTP.config(s)
+
+    assert c[:relay] == "smtp.mail.op"
+    assert c[:port] == 465
+    assert c[:ssl] == true
+    assert %{sockopts: [verify: :verify_peer, cacerts: cacerts]} = c
+    assert is_list(cacerts)
+    assert length(cacerts) > 0
+
+    # explicit port overrides default
+    c2 = Proca.Service.SMTP.config(%{s | host: "smtps://smtp.mail.op:246"})
+    assert c2[:port] == 246
+
+    # ssl:// and smtps:// both produce ssl: true with sockopts
+    c3 = Proca.Service.SMTP.config(%{s | host: "smtps://secure.org:587"})
+    assert c3[:ssl] == true
+    assert c3[:port] == 587
+    assert %{sockopts: [verify: :verify_peer, cacerts: _]} = c3
   end
 end

--- a/test/service/smtp_test.exs
+++ b/test/service/smtp_test.exs
@@ -10,7 +10,7 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 25
     assert c[:tls] == :always
-    assert %{tls_options: [verify: :verify_peer, cacerts: cacerts]} = c
+    assert [verify: :verify_peer, cacerts: cacerts] = c[:tls_options]
     assert is_list(cacerts)
     assert length(cacerts) > 0
 
@@ -23,7 +23,7 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "secure.org"
     assert c[:port] == 465
     assert c[:ssl] == true
-    assert %{sockopts: [verify: :verify_peer, cacerts: cacerts2]} = c
+    assert [verify: :verify_peer, cacerts: cacerts2] = c[:sockopts]
     assert is_list(cacerts2)
     assert length(cacerts2) > 0
   end
@@ -35,7 +35,7 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 465
     assert c[:ssl] == true
-    assert %{sockopts: [verify: :verify_peer, cacerts: cacerts]} = c
+    assert [verify: :verify_peer, cacerts: cacerts] = c[:sockopts]
     assert is_list(cacerts)
     assert length(cacerts) > 0
 
@@ -47,7 +47,7 @@ defmodule Proca.Service.SMTPTest do
     c3 = Proca.Service.SMTP.config(%{s | host: "smtps://secure.org:587"})
     assert c3[:ssl] == true
     assert c3[:port] == 587
-    assert %{sockopts: [verify: :verify_peer, cacerts: _]} = c3
+    assert [verify: :verify_peer, cacerts: _] = c3[:sockopts]
   end
 
   describe "deliver/2" do

--- a/test/service/smtp_test.exs
+++ b/test/service/smtp_test.exs
@@ -21,7 +21,7 @@ defmodule Proca.Service.SMTPTest do
     c = Proca.Service.SMTP.config(%{@tls_service | host: "ssl://secure.org"})
 
     assert c[:relay] == "secure.org"
-    assert c[:port] == 587
+    assert c[:port] == 465
     assert c[:ssl] == true
     assert %{sockopts: [verify: :verify_peer, cacerts: cacerts2]} = c
     assert is_list(cacerts2)
@@ -48,5 +48,29 @@ defmodule Proca.Service.SMTPTest do
     assert c3[:ssl] == true
     assert c3[:port] == 587
     assert %{sockopts: [verify: :verify_peer, cacerts: _]} = c3
+  end
+
+  describe "deliver/2" do
+    test "empty list returns :ok" do
+      org = %Proca.Org{
+        name: "test-org",
+        email_backend: %Service{
+          user: "u",
+          password: "p",
+          host: "tls://smtp.example.com"
+        }
+      }
+
+      assert Proca.Service.SMTP.deliver([], org) == :ok
+    end
+
+    test "put_message_id sets Message-Id header" do
+      email =
+        Swoosh.Email.new(to: {"Test", "test@example.com"})
+        |> Swoosh.Email.put_private(:custom_id, "action:42")
+
+      result = Proca.Service.SMTP.put_message_id(email)
+      assert result.headers["Message-Id"] == "action:42"
+    end
   end
 end


### PR DESCRIPTION
…s:// scheme

OTP requires verify: :verify_peer and a CA cert source when SSL/TLS is enabled. Add them via :sockopts (ssl/smtps scheme)   and :tls_options (tls scheme),
Also add smtps:// as scheme and remove castore dependency