### PR TITLE
Add server name indication

### DIFF
--- a/lib/proca/service/smtp.ex
+++ b/lib/proca/service/smtp.ex
@@ -71,19 +71,9 @@ defmodule Proca.Service.SMTP do
     end
   end
 
-  def put_security(opts, "ssl") do
-    [{:ssl, true} | opts]
-    |> Keyword.update(:port, 465, fn
-      nil -> 465
-      x -> x
-    end)
-    |> Keyword.put(:sockopts, [
-      verify: :verify_peer,
-      cacerts: @cacerts
-    ])
-  end
+  def put_security(opts, scheme) when scheme in ["ssl", "smtps"] do
+    host = opts[:relay]
 
-  def put_security(opts, "smtps") do
     [{:ssl, true} | opts]
     |> Keyword.update(:port, 465, fn
       nil -> 465
@@ -91,11 +81,14 @@ defmodule Proca.Service.SMTP do
     end)
     |> Keyword.put(:sockopts, [
       verify: :verify_peer,
-      cacerts: @cacerts
+      cacerts: @cacerts,
+      server_name_indication: to_charlist(host)
     ])
   end
 
   def put_security(opts, "tls") do
+    host = opts[:relay]
+
     [{:tls, :always} | opts]
     |> Keyword.update(:port, 25, fn
       nil -> 25
@@ -103,7 +96,8 @@ defmodule Proca.Service.SMTP do
     end)
     |> Keyword.put(:tls_options, [
       verify: :verify_peer,
-      cacerts: @cacerts
+      cacerts: @cacerts,
+      server_name_indication: to_charlist(host)
     ])
   end
 

--- a/test/service/smtp_test.exs
+++ b/test/service/smtp_test.exs
@@ -10,7 +10,7 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 25
     assert c[:tls] == :always
-    assert [verify: :verify_peer, cacerts: cacerts] = c[:tls_options]
+    assert [verify: :verify_peer, cacerts: cacerts, server_name_indication: 'smtp.mail.op'] = c[:tls_options]
     assert is_list(cacerts)
     assert length(cacerts) > 0
 
@@ -23,7 +23,7 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "secure.org"
     assert c[:port] == 465
     assert c[:ssl] == true
-    assert [verify: :verify_peer, cacerts: cacerts2] = c[:sockopts]
+    assert [verify: :verify_peer, cacerts: cacerts2, server_name_indication: 'secure.org'] = c[:sockopts]
     assert is_list(cacerts2)
     assert length(cacerts2) > 0
   end
@@ -35,7 +35,7 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 465
     assert c[:ssl] == true
-    assert [verify: :verify_peer, cacerts: cacerts] = c[:sockopts]
+    assert [verify: :verify_peer, cacerts: cacerts, server_name_indication: 'smtp.mail.op'] = c[:sockopts]
     assert is_list(cacerts)
     assert length(cacerts) > 0
 
@@ -47,7 +47,7 @@ defmodule Proca.Service.SMTPTest do
     c3 = Proca.Service.SMTP.config(%{s | host: "smtps://secure.org:587"})
     assert c3[:ssl] == true
     assert c3[:port] == 587
-    assert [verify: :verify_peer, cacerts: _] = c3[:sockopts]
+    assert [verify: :verify_peer, cacerts: _, server_name_indication: 'secure.org'] = c3[:sockopts]
   end
 
   describe "deliver/2" do


### PR DESCRIPTION
May fix the issue 

Set SNI explicitly in SMTP TLS config so the server receives the correct hostname during handshake, fixing TLS failures with HubSpot and other providers that host multiple domains on the same IP.

Docs ref](https://www.erlang.org/doc/apps/ssl/ssl.html#connect/4)