### PR TITLE
Cert validation should be less strict

### DIFF
--- a/lib/proca/service/smtp.ex
+++ b/lib/proca/service/smtp.ex
@@ -82,7 +82,8 @@ defmodule Proca.Service.SMTP do
     |> Keyword.put(:sockopts, [
       verify: :verify_peer,
       cacerts: @cacerts,
-      server_name_indication: to_charlist(host)
+      server_name_indication: to_charlist(host),
+      verify_fun: {&verify_cert/3, []}
     ])
   end
 
@@ -97,9 +98,16 @@ defmodule Proca.Service.SMTP do
     |> Keyword.put(:tls_options, [
       verify: :verify_peer,
       cacerts: @cacerts,
-      server_name_indication: to_charlist(host)
+      server_name_indication: to_charlist(host),
+      verify_fun: {&verify_cert/3, []}
     ])
   end
+
+  defp verify_cert(_cert, {:bad_cert, :max_path_length_reached}, state), do: {:valid, state}
+  defp verify_cert(_cert, {:extension, _}, state), do: {:unknown, state}
+  defp verify_cert(_cert, :valid, state), do: {:valid, state}
+  defp verify_cert(_cert, :valid_peer, state), do: {:valid, state}
+  defp verify_cert(_cert, reason, _state), do: {:fail, reason}
 
   @impl true
   def handle_bounce(_), do: :ok

--- a/test/service/smtp_test.exs
+++ b/test/service/smtp_test.exs
@@ -10,9 +10,12 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 25
     assert c[:tls] == :always
-    assert [verify: :verify_peer, cacerts: cacerts, server_name_indication: 'smtp.mail.op'] = c[:tls_options]
-    assert is_list(cacerts)
-    assert length(cacerts) > 0
+    assert c[:tls_options][:verify] == :verify_peer
+    assert c[:tls_options][:server_name_indication] == 'smtp.mail.op'
+    assert is_list(c[:tls_options][:cacerts])
+    assert length(c[:tls_options][:cacerts]) > 0
+    assert {vf, []} = c[:tls_options][:verify_fun]
+    assert is_function(vf)
 
     c = Proca.Service.SMTP.config(%{@tls_service | host: @tls_service.host <> ":1234"})
 
@@ -23,9 +26,10 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "secure.org"
     assert c[:port] == 465
     assert c[:ssl] == true
-    assert [verify: :verify_peer, cacerts: cacerts2, server_name_indication: 'secure.org'] = c[:sockopts]
-    assert is_list(cacerts2)
-    assert length(cacerts2) > 0
+    assert c[:sockopts][:verify] == :verify_peer
+    assert c[:sockopts][:server_name_indication] == 'secure.org'
+    assert is_list(c[:sockopts][:cacerts])
+    assert length(c[:sockopts][:cacerts]) > 0
   end
 
   test "smtps config" do
@@ -35,9 +39,10 @@ defmodule Proca.Service.SMTPTest do
     assert c[:relay] == "smtp.mail.op"
     assert c[:port] == 465
     assert c[:ssl] == true
-    assert [verify: :verify_peer, cacerts: cacerts, server_name_indication: 'smtp.mail.op'] = c[:sockopts]
-    assert is_list(cacerts)
-    assert length(cacerts) > 0
+    assert c[:sockopts][:verify] == :verify_peer
+    assert c[:sockopts][:server_name_indication] == 'smtp.mail.op'
+    assert is_list(c[:sockopts][:cacerts])
+    assert length(c[:sockopts][:cacerts]) > 0
 
     # explicit port overrides default
     c2 = Proca.Service.SMTP.config(%{s | host: "smtps://smtp.mail.op:246"})
@@ -47,7 +52,8 @@ defmodule Proca.Service.SMTPTest do
     c3 = Proca.Service.SMTP.config(%{s | host: "smtps://secure.org:587"})
     assert c3[:ssl] == true
     assert c3[:port] == 587
-    assert [verify: :verify_peer, cacerts: _, server_name_indication: 'secure.org'] = c3[:sockopts]
+    assert c3[:sockopts][:verify] == :verify_peer
+    assert c3[:sockopts][:server_name_indication] == 'secure.org'
   end
 
   describe "deliver/2" do


### PR DESCRIPTION
Allow SMTP connections to servers with cert chains that exceed pathLenConstraint, which Erlang enforces strictly but OpenSSL ignores.

HubSpot sends a 3-level certificate chain where the intermediate CA has `pathlen:0`, but the chain violates it. Erlang rejects this with {bad_cert, max_path_length_reached}; OpenSSL and curl accept it fine. We add a verify_fun that allows this specific error while keeping all other certificate checks enforced.