### PR TITLE
Fix duplicate Content-Type header in json_request POST

### DIFF
--- a/lib/proca/service.ex
+++ b/lib/proca/service.ex
@@ -244,7 +244,7 @@ defmodule Proca.Service do
       req
       | method: :post,
         body: body,
-        headers: [{"Content-Type", "application/json"} | req.headers]
+        headers: req.headers
     }
     |> json_request_opts(rest, srv)
   end


### PR DESCRIPTION
The Tesla.Middleware.JSON middleware automatically adds Content-Type: application/json to every POST request it encodes. The code was also adding  `Content-Type: application/json` in `json_request_opts`, resulting in the header being sent twice.

The theory on why it was working so far:  other providers either ignore or accept duplicate headers. HubSpot's gateway is stricter and rejects requests with duplicate Content-Type headers with an empty 400 response (confirmed with curl)

The fix removes the manual header and lets Tesla handle it.