### PR TITLE
 Do not preencode lookup body, let Tesla hadle it

### DIFF
--- a/lib/proca/service/detail.ex
+++ b/lib/proca/service/detail.ex
@@ -110,11 +110,10 @@ defmodule Proca.Service.Detail do
         %Org{id: org_id, name: org_name, detail_backend: %{name: :webhook} = srv},
         %Supporter{email: email, fingerprint: ref}
       ) do
-    payload =
-      Jason.encode!(%{
-        "email" => email,
-        "contactRef" => Supporter.base_encode(ref)
-      })
+    payload = %{
+      "email" => email,
+      "contactRef" => Supporter.base_encode(ref)
+    }
 
     case Service.json_request(srv, srv.host, post: payload, auth: Service.Webhook.auth_type(srv)) do
       {:ok, 200, data} when is_map(data) ->


### PR DESCRIPTION
The detail lookup was pre-encoding the payload to a JSON binary before passing it to json_request. This accidentally bypassed Tesla.Middleware.JSON, which skips encoding (and skips adding Content-Type) when the body is already a binary. The fix passes the raw map instead, letting Tesla handle encoding and set the Content-Type: application/json header correctly.

This should fix lookup failure after #442 