### PR TITLE
Fix mustache error handling across all MTT email compilation paths

### DIFF
--- a/lib/proca/action/message.ex
+++ b/lib/proca/action/message.ex
@@ -55,23 +55,26 @@ defmodule Proca.Action.Message do
     if is_nil(action_page.campaign.mtt) do
       add_error(action, :mtt, "Campaign does not support MTT")
     else
-      {_, message_content} =
-        Proca.Repo.insert(Action.MessageContent.changeset(%Action.MessageContent{}, attrs))
+      case Proca.Repo.insert(Action.MessageContent.changeset(%Action.MessageContent{}, attrs)) do
+        {:ok, message_content} ->
+          messages =
+            Enum.map(targets, fn t ->
+              %{
+                target_id: t,
+                message_content: message_content,
+                files: Map.get(attrs, :files, [])
+              }
+            end)
 
-      # which ever we have - failed changeset or good record, lets just add it once
+          action
+          |> cast(%{messages: messages}, [])
+          |> cast_assoc(:messages)
 
-      messages =
-        Enum.map(targets, fn t ->
-          %{
-            target_id: t,
-            message_content: message_content,
-            files: Map.get(attrs, :files, [])
-          }
-        end)
-
-      action
-      |> cast(%{messages: messages}, [])
-      |> cast_assoc(:messages)
+        {:error, changeset} ->
+          Enum.reduce(changeset.errors, action, fn {field, {msg, opts}}, action ->
+            add_error(action, field, msg, opts)
+          end)
+      end
     end
   end
 

--- a/lib/proca/action/message.ex
+++ b/lib/proca/action/message.ex
@@ -55,26 +55,26 @@ defmodule Proca.Action.Message do
     if is_nil(action_page.campaign.mtt) do
       add_error(action, :mtt, "Campaign does not support MTT")
     else
-      case Proca.Repo.insert(Action.MessageContent.changeset(%Action.MessageContent{}, attrs)) do
-        {:ok, message_content} ->
-          messages =
-            Enum.map(targets, fn t ->
-              %{
-                target_id: t,
-                message_content: message_content,
-                files: Map.get(attrs, :files, [])
-              }
-            end)
+      # Accept any template from the frontend — malformed mustache is caught at
+      # send time: logged, Sentry-captured, raw string sent as fallback.
+      {:ok, message_content} =
+        Proca.Repo.insert(%Action.MessageContent{
+          subject: Map.get(attrs, :subject, ""),
+          body: Map.get(attrs, :body, "")
+        })
 
-          action
-          |> cast(%{messages: messages}, [])
-          |> cast_assoc(:messages)
+      messages =
+        Enum.map(targets, fn t ->
+          %{
+            target_id: t,
+            message_content: message_content,
+            files: Map.get(attrs, :files, [])
+          }
+        end)
 
-        {:error, changeset} ->
-          Enum.reduce(changeset.errors, action, fn {field, {msg, opts}}, action ->
-            add_error(action, field, msg, opts)
-          end)
-      end
+      action
+      |> cast(%{messages: messages}, [])
+      |> cast_assoc(:messages)
     end
   end
 

--- a/lib/proca/server/mtt_context.ex
+++ b/lib/proca/server/mtt_context.ex
@@ -390,15 +390,19 @@ defmodule Proca.Server.MTTContext do
       message_body: body
     })
 
+    action_id = email.assigns[:action_id]
+
     body =
-      body
-      |> EmailTemplate.compile_string()
-      |> EmailTemplate.render_string(target_assigns)
+      case compile_mtt_field(body, "body", "action_id=#{action_id}") do
+        nil -> body
+        compiled -> EmailTemplate.render_string(compiled, target_assigns)
+      end
 
     subject =
-      subject
-      |> EmailTemplate.compile_string()
-      |> EmailTemplate.render_string(target_assigns)
+      case compile_mtt_field(subject, "subject", "action_id=#{action_id}") do
+        nil -> subject
+        compiled -> EmailTemplate.render_string(compiled, target_assigns)
+      end
 
     html_body = EmailMerge.plain_to_html(body)
 
@@ -418,6 +422,24 @@ defmodule Proca.Server.MTTContext do
     email
     |> Email.assign(:body, html_body)
     |> Email.assign(:subject, subject)
+  end
+
+  defp compile_mtt_field(value, field, context) do
+    case EmailTemplate.safe_compile_string(value) do
+      {:ok, compiled} ->
+        compiled
+
+      {:error, reason} ->
+        Logger.warning(
+          "MTT message #{field} has invalid mustache template #{context} reason=#{inspect(reason)}"
+        )
+
+        Sentry.capture_message("Malformed mustache tag in MTT message #{field}",
+          extra: %{reason: inspect(reason)}
+        )
+
+        nil
+    end
   end
 
   defp change_test_subject(message_content, false), do: message_content

--- a/lib/proca/server/mtt_worker.ex
+++ b/lib/proca/server/mtt_worker.ex
@@ -246,8 +246,26 @@ defmodule Proca.Server.MTTWorker do
       msgs
       |> Enum.map(& &1.message_content)
       |> Enum.uniq_by(& &1.id)
-      |> Enum.map(fn mc -> {mc.id, MessageContent.compile(mc)} end)
+      |> Enum.map(fn mc ->
+        try do
+          {mc.id, MessageContent.compile(mc)}
+        catch
+          :throw, {:incorrect_format, reason} ->
+            Logger.warning(
+              "MTT message_content #{mc.id} has invalid mustache template (#{inspect(reason)}), skipping"
+            )
+
+            {mc.id, :invalid}
+        end
+      end)
       |> Map.new()
+
+    {invalid_msgs, msgs} = Enum.split_with(msgs, &(compiled_contents[&1.message_content.id] == :invalid))
+
+    if invalid_msgs != [] do
+      # can't retry a template that will never compile, mark sent to stop the loop
+      Message.mark_all(invalid_msgs, :sent)
+    end
 
     msgs_per_locale = Enum.group_by(msgs, &(&1.target.locale || @default_locale))
 

--- a/lib/proca/server/mtt_worker.ex
+++ b/lib/proca/server/mtt_worker.ex
@@ -247,25 +247,11 @@ defmodule Proca.Server.MTTWorker do
       |> Enum.map(& &1.message_content)
       |> Enum.uniq_by(& &1.id)
       |> Enum.map(fn mc ->
-        try do
-          {mc.id, MessageContent.compile(mc)}
-        catch
-          :throw, {:incorrect_format, reason} ->
-            Logger.warning(
-              "MTT message_content #{mc.id} has invalid mustache template (#{inspect(reason)}), skipping"
-            )
-
-            {mc.id, :invalid}
-        end
+        cs = compile_mtt_field(mc.subject, "subject", "mc_id=#{mc.id}")
+        cb = compile_mtt_field(mc.body, "body", "mc_id=#{mc.id}")
+        {mc.id, %{mc | compiled: %{subject: cs, body: cb}}}
       end)
       |> Map.new()
-
-    {invalid_msgs, msgs} = Enum.split_with(msgs, &(compiled_contents[&1.message_content.id] == :invalid))
-
-    if invalid_msgs != [] do
-      # can't retry a template that will never compile, mark sent to stop the loop
-      Message.mark_all(invalid_msgs, :sent)
-    end
 
     msgs_per_locale = Enum.group_by(msgs, &(&1.target.locale || @default_locale))
 
@@ -425,27 +411,9 @@ defmodule Proca.Server.MTTWorker do
           {cs, cb}
 
         nil ->
-          cs =
-            try do
-              EmailTemplate.compile_string(subject)
-            catch
-              :exit, {:incorrect_format, reason} ->
-                Sentry.capture_message("Malformed mustache tag in MTT message subject",
-                  extra: %{reason: inspect(reason), action_id: email.assigns[:action_id], subject: subject}
-                )
-                nil
-            end
-
-          cb =
-            try do
-              EmailTemplate.compile_string(body)
-            catch
-              :exit, {:incorrect_format, reason} ->
-                Sentry.capture_message("Malformed mustache tag in MTT message body",
-                  extra: %{reason: inspect(reason), action_id: email.assigns[:action_id], body: body}
-                )
-                nil
-            end
+          action_id = email.assigns[:action_id]
+          cs = compile_mtt_field(subject, "subject", "action_id=#{action_id}")
+          cb = compile_mtt_field(body, "body", "action_id=#{action_id}")
 
           {cs, cb}
       end
@@ -483,6 +451,24 @@ defmodule Proca.Server.MTTWorker do
 
   defp maybe_add_cc(email, cc, true), do: Email.cc(email, cc)
   defp maybe_add_cc(email, _cc, false), do: email
+
+  defp compile_mtt_field(value, field, context) do
+    case EmailTemplate.safe_compile_string(value) do
+      {:ok, compiled} ->
+        compiled
+
+      {:error, reason} ->
+        Logger.warning(
+          "MTT message #{field} has invalid mustache template #{context} reason=#{inspect(reason)}"
+        )
+
+        Sentry.capture_message("Malformed mustache tag in MTT message #{field}",
+          extra: %{reason: inspect(reason)}
+        )
+
+        nil
+    end
+  end
 
   defp max_messages_per_cycle() do
     max_messages = Application.get_env(:proca, __MODULE__)[:max_messages_per_cycle]

--- a/lib/proca/service/email_template.ex
+++ b/lib/proca/service/email_template.ex
@@ -72,6 +72,12 @@ defmodule Proca.Service.EmailTemplate do
             e ->
               [{field, "Invalid template in #{field}: #{inspect(e)}"}]
           end
+      catch
+        :throw, {:incorrect_format, reason} ->
+          [
+            {field,
+             {"Invalid mustache template format in #{field}: #{inspect(reason)}", [reason]}}
+          ]
       end
     end)
   end

--- a/lib/proca/service/email_template.ex
+++ b/lib/proca/service/email_template.ex
@@ -72,12 +72,6 @@ defmodule Proca.Service.EmailTemplate do
             e ->
               [{field, "Invalid template in #{field}: #{inspect(e)}"}]
           end
-      catch
-        :throw, {:incorrect_format, reason} ->
-          [
-            {field,
-             {"Invalid mustache template format in #{field}: #{inspect(reason)}", [reason]}}
-          ]
       end
     end)
   end
@@ -135,6 +129,16 @@ defmodule Proca.Service.EmailTemplate do
 
   def compile_string(m) do
     :bbmustache.parse_binary(m)
+  end
+
+  def safe_compile_string(nil), do: {:ok, nil}
+
+  def safe_compile_string(m) do
+    try do
+      {:ok, compile_string(m)}
+    catch
+      :error, {:incorrect_format, reason} -> {:error, reason}
+    end
   end
 
   # when end is_tuple(m) do

--- a/test/proca_web/api/action_test.exs
+++ b/test/proca_web/api/action_test.exs
@@ -345,4 +345,32 @@ defmodule ProcaWeb.Api.ActionTest do
     mc_count_2 = Repo.one(from(mc in Proca.Action.MessageContent, select: count(mc.id)))
     assert mc_count_2 == 2
   end
+
+  test "reject mtt action with invalid mustache template", %{org: org, campaign: c, pages: [ap]} do
+    Repo.update!(
+      Campaign.changeset(
+        Repo.preload(c, [:mtt]),
+        %{mtt: %{start_at: ~N[2022-01-01 10:00:00], end_at: ~N[2022-01-10 18:00:00]}}
+      )
+    )
+
+    targets = Factory.insert_list(3, :target)
+    mc_count_before = Repo.one(from(mc in Proca.Action.MessageContent, select: count(mc.id)))
+
+    action_with_contact_invalid(
+      ap,
+      %{
+        action_type: "mtt",
+        mtt: %{
+          targets: Enum.map(targets, & &1.id),
+          subject: "Hello",
+          body: "Our demands are: {{#unclosed}}"
+        }
+      },
+      %{first_name: "Frank", email: "frank@email.com"}
+    )
+
+    mc_count_after = Repo.one(from(mc in Proca.Action.MessageContent, select: count(mc.id)))
+    assert mc_count_after == mc_count_before
+  end
 end

--- a/test/proca_web/api/action_test.exs
+++ b/test/proca_web/api/action_test.exs
@@ -346,7 +346,7 @@ defmodule ProcaWeb.Api.ActionTest do
     assert mc_count_2 == 2
   end
 
-  test "reject mtt action with invalid mustache template", %{org: org, campaign: c, pages: [ap]} do
+  test "accept mtt action with invalid mustache template", %{org: org, campaign: c, pages: [ap]} do
     Repo.update!(
       Campaign.changeset(
         Repo.preload(c, [:mtt]),
@@ -357,7 +357,7 @@ defmodule ProcaWeb.Api.ActionTest do
     targets = Factory.insert_list(3, :target)
     mc_count_before = Repo.one(from(mc in Proca.Action.MessageContent, select: count(mc.id)))
 
-    action_with_contact_invalid(
+    action_with_contact(
       ap,
       %{
         action_type: "mtt",
@@ -371,6 +371,6 @@ defmodule ProcaWeb.Api.ActionTest do
     )
 
     mc_count_after = Repo.one(from(mc in Proca.Action.MessageContent, select: count(mc.id)))
-    assert mc_count_after == mc_count_before
+    assert mc_count_after == mc_count_before + 1
   end
 end

--- a/test/server/mtt_worker_test.exs
+++ b/test/server/mtt_worker_test.exs
@@ -4,12 +4,13 @@ defmodule Proca.Server.MTTWorkerTest do
 
   import Proca.StoryFactory, only: [green_story: 0]
   import Ecto.Query
+  import ExUnit.CaptureLog
 
   alias Proca.Repo
   alias Proca.Factory
 
   alias Proca.Server.MTTWorker
-  alias Proca.Action.Message
+  alias Proca.Action.{Message, MessageContent}
 
   use Proca.TestEmailBackend
   use Proca.TestProcessing
@@ -321,6 +322,68 @@ defmodule Proca.Server.MTTWorkerTest do
     } do
       emails = MTTWorker.get_emails_to_send([tid1, tid2], {700, 700})
       assert length(emails) == 99
+    end
+  end
+
+  describe "put_message_content with malformed supporter template (drip path nil branch)" do
+    test "falls back to raw subject/body and logs a warning" do
+      email =
+        Swoosh.Email.new()
+        |> Swoosh.Email.assign(:action_id, 42)
+        |> Swoosh.Email.assign(:target, %{"name" => "Parliament"})
+
+      bad_mc = %MessageContent{subject: "{{#unclosed}}", body: "Our demands", compiled: nil}
+
+      log =
+        capture_log(fn ->
+          result = MTTWorker.put_message_content(email, bad_mc, nil)
+          assert result.subject == "{{#unclosed}}"
+          assert result.text_body == "Our demands"
+        end)
+
+      IO.puts("\n[path 3 log] #{log}")
+      assert log =~ "invalid mustache template"
+      assert log =~ "action_id=42"
+    end
+  end
+
+  describe "mtt_context no-drip path with malformed supporter template" do
+    test "compile_string signals :error class — mtt_context now catches it" do
+      assert_raise ErlangError, ~r/incorrect_format/, fn ->
+        Proca.Service.EmailTemplate.compile_string("{{#unclosed}}")
+      end
+    end
+  end
+
+  describe "send_emails with malformed mustache" do
+    setup %{campaign: c, ap: ap, targets: [t | _]} do
+      action =
+        Factory.insert(:action,
+          action_page: ap,
+          processing_status: :delivered,
+          supporter_processing_status: :accepted
+        )
+
+      bad_mc = Repo.insert!(%MessageContent{subject: "{{#unclosed}}", body: "body"})
+      msg = Factory.insert(:message, action: action, target: t, message_content: bad_mc)
+
+      msgs =
+        Repo.all(
+          from(m in Message,
+            where: m.id == ^msg.id,
+            preload: [[target: :emails], [action: :supporter], :message_content]
+          )
+        )
+
+      %{msgs: msgs, msg_id: msg.id}
+    end
+
+    test "sends email with raw fallback string and logs a warning", %{campaign: c, msgs: msgs, msg_id: msg_id} do
+      log = capture_log(fn -> MTTWorker.send_emails(c, msgs) end)
+
+      IO.puts("\n[path 2 log] #{log}")
+      assert log =~ "invalid mustache template"
+      assert Repo.get!(Message, msg_id).sent == true
     end
   end
 end

--- a/test/service/email_template_test.exs
+++ b/test/service/email_template_test.exs
@@ -34,6 +34,33 @@ defmodule Proca.EmailTemplateTest do
     assert String.contains?(email.html_body, "You decided to subscribe")
   end
 
+  test "compile_string signals :error class (not :throw or :exit) on malformed template" do
+    try do
+      EmailTemplate.compile_string("{{#unclosed}}")
+      flunk("expected compile_string to raise on malformed template")
+    catch
+      :error, {:incorrect_format, _} -> :ok
+      kind, reason -> flunk("expected :error class signal, got :#{kind}: #{inspect(reason)}")
+    end
+  end
+
+  test "changeset validation logs nothing — error is returned to the caller", %{org: org} do
+    import ExUnit.CaptureLog
+
+    log =
+      capture_log(fn ->
+        EmailTemplate.changeset(%{
+          org: org,
+          name: "broken template",
+          locale: "en",
+          subject: "Hello {{#unclosed}}",
+          html: "<p>Valid html</p>"
+        })
+      end)
+
+    assert log == ""
+  end
+
   test "changeset rejects template with invalid mustache in subject", %{org: org} do
     ch = EmailTemplate.changeset(%{
       org: org,


### PR DESCRIPTION
Fix #430 
Related PR https://github.com/fixthestatusquo/proca-server/pull/433


bbmustache raises via `error/1` (Erlang :error class), not `throw/1` or `exit/1`. Preexisting code was silently missing parse errors. 
This PR corrects all four MTT template compilation paths to catch the right signal class and behave consistently.

**Consistent behavior:** when a mustache template fails to compile, log a warning with the field name and action/message context, capture to Sentry, and fall back to sending the raw unrendered string. No message is silently dropped or marked sent without an attempt to deliver.

## MTT template workflows

MTT emails go through one of two delivery paths depending on `mtt.drip_delivery`:

**Drip path** (`mtt_worker.ex`) — scheduler wakes up periodically and batches messages per campaign:
1. **Pre-compilation** before sending, all `MessageContent` records are compiled into a `compiled_contents` map. If a template is invalid, the bad field is `nil` and the raw string is used as a fallback.
2. **Test action nil branch:** `change_test_subject` prepends `[TEST]` to the subject and sets `compiled: nil`, forcing re-compilation at send time. Previously unguarded.

**No-drip path** (`mtt_context.ex`) — one message sent per scheduler tick:
`put_message_content` called directly with raw subject/body. Previously called `compile_string` with no error handling — a bad template would crash the scheduler process.

**API submission** (`message.ex` / GraphQL): any template is accepted from the frontend and stored as-is. The original code intended this but was broken — `Repo.insert` with a failed changeset returns `{:error, changeset}`, not the struct. Fixed by inserting `MessageContent` directly without changeset validation. Malformed mustache is caught at send time instead.







